### PR TITLE
Hacky fix for TurnToFinal objects.

### DIFF
--- a/src/main/java/org/ngafid/common/Compression.java
+++ b/src/main/java/org/ngafid/common/Compression.java
@@ -85,11 +85,24 @@ public class Compression {
         return compress(bytes.array());
     }
 
+    public static Object inflateTTFObject(byte[] bytes) throws IOException, ClassNotFoundException {
+        byte[] inflated = inflate(bytes);
+
+        // Deserialize
+        // Use the custom TTFFixObjectInputStream which will properly recognize the outdated reference to the turn to final class
+        ObjectInputStream inputStream = new TTFFixObjectInputStream(new ByteArrayInputStream(inflated)); // new ObjectInputStream(new ByteArrayInputStream(inflated));
+        Object o = inputStream.readObject();
+        inputStream.close();
+
+        return o;
+    }
+
+
     public static Object inflateObject(byte[] bytes) throws IOException, ClassNotFoundException {
         byte[] inflated = inflate(bytes);
 
         // Deserialize
-        ObjectInputStream inputStream = new TTFFixObjectInputStream(new ByteArrayInputStream(inflated)); // new ObjectInputStream(new ByteArrayInputStream(inflated));
+        ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(inflated));
         Object o = inputStream.readObject();
         inputStream.close();
 

--- a/src/main/java/org/ngafid/common/Compression.java
+++ b/src/main/java/org/ngafid/common/Compression.java
@@ -8,7 +8,28 @@ import java.sql.SQLException;
 import java.util.logging.Logger;
 import java.util.zip.*;
 
+import org.ngafid.flights.calculations.TurnToFinal;
+
 public class Compression {
+
+    private static class TTFFixObjectInputStream extends ObjectInputStream {
+        public TTFFixObjectInputStream() throws IOException {
+            super();
+        }
+
+        public TTFFixObjectInputStream(InputStream in) throws IOException {
+            super(in);
+        }
+
+        protected ObjectStreamClass readClassDescriptor() throws IOException, ClassNotFoundException {
+            ObjectStreamClass read = super.readClassDescriptor();
+            if (read.getName().equals("org.ngafid.flights.TurnToFinal")) {
+                return ObjectStreamClass.lookup(TurnToFinal.class);
+            } else {
+                return read;
+            }
+        }
+    }
 
     private static Logger LOG = Logger.getLogger(Compression.class.getName());
 
@@ -68,7 +89,7 @@ public class Compression {
         byte[] inflated = inflate(bytes);
 
         // Deserialize
-        ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(inflated));
+        ObjectInputStream inputStream = new TTFFixObjectInputStream(new ByteArrayInputStream(inflated)); // new ObjectInputStream(new ByteArrayInputStream(inflated));
         Object o = inputStream.readObject();
         inputStream.close();
 

--- a/src/main/java/org/ngafid/flights/calculations/TurnToFinal.java
+++ b/src/main/java/org/ngafid/flights/calculations/TurnToFinal.java
@@ -272,7 +272,7 @@ public class TurnToFinal implements Serializable {
             ArrayList<TurnToFinal> ttfs = (ArrayList<TurnToFinal>) o;
             cacheTurnToFinal(connection, flight.getId(), ttfs);
 
-            return null;
+            return ttfs;
         }
 
     }

--- a/src/main/java/org/ngafid/flights/calculations/TurnToFinal.java
+++ b/src/main/java/org/ngafid/flights/calculations/TurnToFinal.java
@@ -220,7 +220,7 @@ public class TurnToFinal implements Serializable {
         blob.free();
     }
 
-    public static ArrayList<TurnToFinal> getTurnToFinalFromCache(Connection connection, Flight flight) throws SQLException, IOException {
+    public static ArrayList<TurnToFinal> getTurnToFinalFromCache(Connection connection, Flight flight) throws SQLException, IOException, ClassNotFoundException {
         PreparedStatement query = connection.prepareStatement("SELECT * FROM turn_to_final WHERE flight_id = ?");
         query.setInt(1, flight.getId());
         LOG.info(query.toString());
@@ -262,6 +262,16 @@ public class TurnToFinal implements Serializable {
             query = connection.prepareStatement("DELETE * FROM turn_to_final WHERE flight_id = ?");
             query.setInt(1, flight.getId());
             LOG.info(query.toString());
+            query.execute();
+            query.close();
+
+            Object o = Compression.inflateTTFObject(values.getBytes(1, (int) values.length()));
+            assert o instanceof ArrayList;
+
+            @SuppressWarnings("unchecked")
+            ArrayList<TurnToFinal> ttfs = (ArrayList<TurnToFinal>) o;
+            cacheTurnToFinal(connection, flight.getId(), ttfs);
+
             return null;
         }
 


### PR DESCRIPTION
Created a custom implementation of the ObjectInputStream class and override the readClassDescriptor method.

This allows us to intercept the incorrect / out dated reference to "org.ngafid.flights.TurnToFinal" found in older objects and replace it with a direct reference to the TurnToFinal class. 

This allows us to detect objects that use the old reference and fix them automatically (done in TurnToFinal.java).

We can either:
1. keep the hacky code in, and things will fix themselves as they are accessed
2. run a quick script to fetch each and every row in the TTF table; doing this using the "getTurnToFinalFromCache" method will fix broken objects.