### PR TITLE
Unsubcribe Links for Email Preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ db/db_info.php
 db/db_info
 email_info.txt
 package-lock.json
+data/archive/*

--- a/db/create_tables.php
+++ b/db/create_tables.php
@@ -574,9 +574,11 @@ if (!$update_2022_02_17) {
     query_ngafid_db($query);
 
 
+    //  query_ngafid_db("DROP TABLE email_unsubscribe_tokens");    
     $query = "CREATE TABLE `email_unsubscribe_tokens` (
         `token` VARCHAR(64) NOT NULL,
         `user_id` INT(11) NOT NULL,
+        `expiration_date` DATETIME NOT NULL,
         PRIMARY KEY (`token`),
         FOREIGN KEY (`user_id`) REFERENCES user(`id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=latin1;";

--- a/db/create_tables.php
+++ b/db/create_tables.php
@@ -574,6 +574,15 @@ if (!$update_2022_02_17) {
     query_ngafid_db($query);
 
 
+    $query = "CREATE TABLE `email_unsubscribe_tokens` (
+        `token` VARCHAR(64) NOT NULL,
+        `user_id` INT(11) NOT NULL,
+        PRIMARY KEY (`token`),
+        FOREIGN KEY (`user_id`) REFERENCES user(`id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=latin1;";
+    query_ngafid_db($query);
+
+
     $query = "CREATE TABLE `stored_filters` (
         `fleet_id` INT(11) NOT NULL,
         `name` VARCHAR(512) NOT NULL,

--- a/db/create_tables.php
+++ b/db/create_tables.php
@@ -573,8 +573,7 @@ if (!$update_2022_02_17) {
     );";
     query_ngafid_db($query);
 
-
-    //  query_ngafid_db("DROP TABLE email_unsubscribe_tokens");    
+    
     $query = "CREATE TABLE `email_unsubscribe_tokens` (
         `token` VARCHAR(64) NOT NULL,
         `user_id` INT(11) NOT NULL,

--- a/src/main/java/org/ngafid/WebServer.java
+++ b/src/main/java/org/ngafid/WebServer.java
@@ -207,6 +207,13 @@ public final class WebServer {
         Spark.get("/reset_password", new GetResetPassword(gson));
         Spark.post("/reset_password", new PostResetPassword(gson));
 
+        //to unsubscribe from emails
+        Spark.get("/email_unsubscribe", new GetEmailUnsubscribe(gson));
+        Spark.after("/email_unsubscribe", (request, response) -> {
+            response.redirect("/");
+        });
+
+
         Spark.get("/protected/welcome", new GetWelcome(gson));
         Spark.get("/protected/aggregate", new GetAggregate(gson));
         Spark.post("/protected/event_counts", new PostEventCounts(gson, false));
@@ -325,6 +332,7 @@ public final class WebServer {
         Spark.post("/protected/preferences_metric", new PostUserPreferencesMetric(gson));
         Spark.post("/protected/update_tail", new PostUpdateTail(gson));
         Spark.post("/protected/update_email_preferences", new PostUpdateUserEmailPreferences(gson));
+        
 
         // Event Definition Management
         Spark.get("/protected/manage_event_definitions", new GetAllEventDefinitions(gson));

--- a/src/main/java/org/ngafid/accounts/EmailType.java
+++ b/src/main/java/org/ngafid/accounts/EmailType.java
@@ -115,6 +115,9 @@ public enum EmailType {
     public static boolean isForced(EmailType emailType) {
         return emailType.getType().contains("FORCED");
     }
+    public static boolean isForced(String emailTypeName) {
+        return emailTypeName.contains("FORCED");
+    }
 
 
     //PHP Execution

--- a/src/main/java/org/ngafid/accounts/EmailType.java
+++ b/src/main/java/org/ngafid/accounts/EmailType.java
@@ -1,11 +1,5 @@
 package org.ngafid.accounts;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
-import java.io.FileWriter;
-import java.io.IOException;
-
 import java.util.*;
 import java.util.logging.Logger;
 
@@ -75,10 +69,20 @@ public enum EmailType {
 
     //Store number of email types
     private final static int emailTypeCount = values().length;
+    private final static int emailTypeNonForcedCount;
 
     private static Logger LOG = Logger.getLogger(EmailType.class.getName());
 
     static {
+
+        int emailTypeNonForcedCounter = 0;
+        for (EmailType emailType : EmailType.values()) {
+            if (!isForced(emailType)) {
+                emailTypeNonForcedCounter++;
+            }
+        }
+        emailTypeNonForcedCount = emailTypeNonForcedCounter;
+
         LOG.info("EmailType class loaded...");
         LOG.info("Detected " + emailTypeCount + " email types");
     }
@@ -96,6 +100,9 @@ public enum EmailType {
 
     public static int getEmailTypeCount() {
         return emailTypeCount;
+    }
+    public static int getEmailTypeCountNonForced() {
+        return emailTypeNonForcedCount;
     }
 
     public static EmailType[] getAllTypes() {

--- a/src/main/java/org/ngafid/accounts/User.java
+++ b/src/main/java/org/ngafid/accounts/User.java
@@ -393,7 +393,7 @@ public class User {
         }
 
 
-        int emailTypeCountExpected = EmailType.getEmailTypeCount();
+        int emailTypeCountExpected = EmailType.getEmailTypeCountNonForced();
 
         LOG.info("Checking email preferences for user with ID (" + userId + ")... Expected: " + emailTypeCountExpected + " / Actual: " + emailPreferencesCount);
 

--- a/src/main/java/org/ngafid/accounts/UserEmailPreferences.java
+++ b/src/main/java/org/ngafid/accounts/UserEmailPreferences.java
@@ -25,8 +25,9 @@ public class UserEmailPreferences {
     private HashMap<String, Boolean> emailTypesUser;
     private String[] emailTypesKeys;
 
-    private static HashMap<Integer, User> users = new HashMap<Integer, User>();
-    private static HashMap<String, HashMap<String, Boolean>> emailTypesUsers = new HashMap<String, HashMap<String, Boolean>>();
+    private static HashMap<Integer, User> users = new HashMap<>();
+    private static HashMap<String, Integer> userIDs = new HashMap<>();
+    private static HashMap<String, HashMap<String, Boolean>> emailTypesUsers = new HashMap<>();
 
     private static final Logger LOG = Logger.getLogger(UserEmailPreferences.class.getName());
 
@@ -48,7 +49,14 @@ public class UserEmailPreferences {
 
     public static void addUser(Connection connection, User user) throws SQLException {
 
-        users.put(user.getId(), user);
+        int userID = user.getId();
+        String userEmail = user.getEmail();
+
+        //user email --> userId
+        userIDs.put(userEmail, userID);
+
+        //userId --> User
+        users.put(userID, user);
 
         emailTypesUsers.put( user.getEmail(), user.getUserEmailPreferences(connection).getEmailTypesUser() );
 
@@ -56,6 +64,10 @@ public class UserEmailPreferences {
 
     public static User getUser(int userId) {
         return users.get(userId);
+    }
+
+    public static int getUserIDFromEmail(String userEmail) {
+        return userIDs.get(userEmail);
     }
 
     public HashMap<String, Boolean> getEmailTypesUser() {

--- a/src/main/java/org/ngafid/routes/GetEmailUnsubscribe.java
+++ b/src/main/java/org/ngafid/routes/GetEmailUnsubscribe.java
@@ -62,7 +62,7 @@ public class GetEmailUnsubscribe implements Route {
             query.setInt(2, id);
             ResultSet resultSet = query.executeQuery();
             if (!resultSet.next()) {
-                String exceptionMessage = "Provided token/id pairing was not found: ("+token+", "+id+"), may have already been used";
+                String exceptionMessage = "Provided token/id pairing was not found: ("+token+", "+id+"), may have already expired or been used";
                 LOG.severe(exceptionMessage);
                 throw new Exception(exceptionMessage);
             }

--- a/src/main/java/org/ngafid/routes/GetEmailUnsubscribe.java
+++ b/src/main/java/org/ngafid/routes/GetEmailUnsubscribe.java
@@ -1,0 +1,105 @@
+package org.ngafid.routes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.lang.reflect.Type;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+
+import spark.Route;
+import spark.Request;
+import spark.Response;
+import spark.Session;
+import spark.Spark;
+
+import org.ngafid.Database;
+import org.ngafid.accounts.User;
+import org.ngafid.accounts.UserPreferences;
+import org.ngafid.accounts.UserEmailPreferences;
+import org.ngafid.accounts.EmailType;
+import org.ngafid.flights.DoubleTimeSeries;
+
+import static org.ngafid.flights.calculations.Parameters.*;
+
+
+
+public class GetEmailUnsubscribe implements Route {
+
+    private static final Logger LOG = Logger.getLogger(GetEmailUnsubscribe.class.getName());
+    private Gson gson;
+    private static Connection connection = Database.getConnection();
+
+    public GetEmailUnsubscribe(Gson gson) {
+        this.gson = gson;
+        LOG.info("email unsubscribe route initialized.");
+    }
+
+    @Override
+    public Object handle(Request request, Response response) throws SQLException {
+
+
+        int id = Integer.parseInt( request.queryParams("id") );
+        String token = request.queryParams("token");
+
+        LOG.info("Attempting to unsubscribe from emails... (id: "+id+", token: "+token+")");
+
+
+        //Check if the token is valid
+        try {
+                
+            PreparedStatement query = connection.prepareStatement("SELECT * FROM email_unsubscribe_tokens WHERE token=? AND user_id=?");
+            query.setString(1, token);
+            query.setInt(2, id);
+            ResultSet resultSet = query.executeQuery();
+            if (!resultSet.next()) {
+                String exceptionMessage = "Provided token/id pairing was not found: ("+token+", "+id+"), may have already been used";
+                LOG.severe(exceptionMessage);
+                throw new Exception(exceptionMessage);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return gson.toJson(new ErrorResponse(e));
+        }
+
+        //Remove the token from the database
+        PreparedStatement queryTokenRemoval;
+        queryTokenRemoval = connection.prepareStatement("DELETE FROM email_unsubscribe_tokens WHERE token=? AND user_id=?");
+        queryTokenRemoval.setString(1, token);
+        queryTokenRemoval.setInt(2, id);
+        queryTokenRemoval.executeUpdate();
+
+        //Set all non-forced email preferences to 0 in the database
+        PreparedStatement queryClearPreferences;
+        queryClearPreferences = connection.prepareStatement("SELECT * FROM email_preferences WHERE user_id=?");
+        queryClearPreferences.setInt(1, id);
+        ResultSet resultSet = queryClearPreferences.executeQuery();
+        
+        while (resultSet.next()) {
+
+            String emailType = resultSet.getString("email_type");
+            if (EmailType.isForced(emailType)) {
+                continue;
+            }
+
+            PreparedStatement update = connection.prepareStatement("UPDATE email_preferences SET enabled=0 WHERE user_id=? AND email_type=?");
+            update.setInt(1, id);
+            update.setString(2, emailType);
+            update.executeUpdate();
+        }
+
+        return "Successfully unsubscribed from emails...";
+    
+    }
+
+}


### PR DESCRIPTION
Adds new links to the top of received emails which, when clicked, will disable all non-forced email types in the database.

Consequently, all standard recipients will have separate emails delivered to support the unique unsubscribe links, as opposed to having them batched like before.

The BCC recipients will get a separate email which does not contain an unsubscribe link.