### PR TITLE
Fix empty default severity columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ db/db_info.php
 db/db_info
 email_info.txt
 package-lock.json
+data/archive/*

--- a/src/main/javascript/create_event.js
+++ b/src/main/javascript/create_event.js
@@ -50,12 +50,15 @@ class CreateEventCard extends React.Component {
             stopBuffer : "",
             severityType : "min",
             severityColumnNames : [],
+            severityColumn : doubleTimeSeriesNames[0],
             filters : {
                 type : "GROUP",
                 condition : "AND",
                 filters : []
-            }
+            },
+            
         }
+        
     }
 
     validateEventName(event) {

--- a/src/main/javascript/manage_events.js
+++ b/src/main/javascript/manage_events.js
@@ -87,6 +87,7 @@ class CreateEventCard extends React.Component {
             stopBuffer : "",
             severityType : "min",
             severityColumnNames : [],
+            severityColumn : doubleTimeSeriesNames[0],
             filters : {
                 type : "GROUP",
                 condition : "AND",
@@ -291,6 +292,7 @@ class UpdateEventDefinitionModal extends React.Component {
             stopBuffer: "",
             severityType: "min",
             severityColumnNames: [],
+            severityColumn: doubleTimeSeriesNames[0],
             filters: {
                 type: "GROUP",
                 condition: "AND",


### PR DESCRIPTION
Records the default value of the Severity Columns so empty values can no longer be added, preventing a potential NullPointerException when managing events or viewing event statistics