### PR TITLE
Fix button access on Uploads page for users with View/Upload privileges

### DIFF
--- a/src/main/java/org/ngafid/routes/GetUpload.java
+++ b/src/main/java/org/ngafid/routes/GetUpload.java
@@ -44,9 +44,10 @@ public class GetUpload implements Route {
             return "Upload not found";
         }
 
-        if (!user.hasUploadAccess(upload.getFleetId())) {
-            LOG.severe("INVALID ACCESS: user did not have upload or manager access this fleet.");
-            Spark.halt(401, "User did not have access to delete this upload.");
+        //Verify that a user has access to the download the uploaded file (requires View Access)
+        if (!user.hasViewAccess(upload.getFleetId())) {
+            LOG.severe("INVALID ACCESS: user did not have view, upload, or manager access this fleet.");
+            Spark.halt(401, "User did not have access to download the uploaded file.");
             return null;
         }
 

--- a/src/main/java/org/ngafid/routes/GetUploads.java
+++ b/src/main/java/org/ngafid/routes/GetUploads.java
@@ -125,6 +125,8 @@ public class GetUploads implements Route {
 
             scopes.put("uploads_js", "var uploads = JSON.parse('" + gson.toJson(other_uploads) + "'); var pending_uploads = JSON.parse('" + gson.toJson(pending_uploads) + "');");
 
+            scopes.put("user_js", "var user = JSON.parse('" + gson.toJson(user)  + "');");
+
             StringWriter stringOut = new StringWriter();
             mustache.execute(new PrintWriter(stringOut), scopes).flush();
             resultString = stringOut.toString();

--- a/src/main/java/org/ngafid/routes/Navbar.java
+++ b/src/main/java/org/ngafid/routes/Navbar.java
@@ -20,6 +20,7 @@ public class Navbar {
         boolean airSyncEnabled = false;
         int waitingUserCount = 0;
         boolean modifyTailsAccess = false;
+        boolean hasUploadAccess = false;
         int unconfirmedTailsCount = 0;
 
         if (user != null && user.getFleetAccessType().equals(FleetAccess.MANAGER)) {
@@ -45,8 +46,9 @@ public class Navbar {
                     airSyncEnabled = resultSet.getBoolean(1);
                 }
 
-                if (user != null && (user.getFleetAccessType().equals(FleetAccess.MANAGER) || user.getFleetAccessType().equals(FleetAccess.UPLOAD))) {
-                    modifyTailsAccess = true;
+                if (user != null) {
+                    modifyTailsAccess = user.hasUploadAccess(fleetId);
+                    hasUploadAccess = user.hasUploadAccess(fleetId);
                     unconfirmedTailsCount = user.getUnconfirmedTailsCount(connection);
                 }
             }
@@ -54,6 +56,13 @@ public class Navbar {
             //don't do anything so the navbar still displays even if there is an issue with the database
         }
 
-        return "var admin = " + user.isAdmin()  + "; var aggregateView = " + user.hasAggregateView() + "; var fleetManager = " + fleetManager + "; var waitingUserCount = " + waitingUserCount + "; var modifyTailsAccess = " + modifyTailsAccess + "; var unconfirmedTailsCount = " + unconfirmedTailsCount + "; var airSyncEnabled = " + airSyncEnabled;
+        return  "var admin = " + user.isAdmin() + ";" 
+            +   "var aggregateView = " + user.hasAggregateView() + ";" 
+            +   "var fleetManager = " + fleetManager + ";"
+            +   "var waitingUserCount = " + waitingUserCount + ";"
+            +   "var modifyTailsAccess = " + modifyTailsAccess + ";" 
+            +   "var unconfirmedTailsCount = " + unconfirmedTailsCount + ";" 
+            +   "var airSyncEnabled = " + airSyncEnabled + ";"
+            +   "var isUploader = " + hasUploadAccess + ";";
     }
 }

--- a/src/main/javascript/uploads.js
+++ b/src/main/javascript/uploads.js
@@ -173,11 +173,13 @@ class Upload extends React.Component {
         const deleteButtonAccess = ["MANAGER", "UPLOAD"];
         let hasDeleteAccess = deleteButtonAccess.includes(this.state.userFleetAccess);
         let doDeleteButtonDisable = (doButtonsDisable || !hasDeleteAccess);
+        let doDeleteButtonHide = (!hasDeleteAccess);
 
         //Disable Delete buttons with no View Access
         const downloadButtonAccess = ["MANAGER", "UPLOAD", "VIEW"];
         let hasDownloadAccess = downloadButtonAccess.includes(this.state.userFleetAccess);
         let doDownloadButtonDisable = (doButtonsDisable || !hasDownloadAccess);
+        let doDownloadButtonHide = (!hasDownloadAccess);
 
         return (
             <div className="m-1">
@@ -189,33 +191,39 @@ class Upload extends React.Component {
                     </div>
                     <div className={statusClasses} style={{flex:"0 0 18em"}}>{statusText}</div>
 
-                    <Button
-                        type="button"
-                        className={"btn btn-danger btn-sm"}
-                        style={{backgroundColor:(doDeleteButtonDisable ? '#444444' : '#DC3545'), width:"34px", marginLeft:"4px", padding:"2 4 4 4"}}
-                        >
-                        <i
-                            className="fa fa-times"
-                            aria-hidden="true"
-                            style={{padding: "4 4 3 4"}}
-                            onClick={ () => (doDeleteButtonDisable ? undefined : this.confirmRemoveUpload()) }
+                    {
+                        (!doDeleteButtonHide) &&
+                        <Button
+                            type="button"
+                            className={"btn btn-danger btn-sm"}
+                            style={{backgroundColor:(doDeleteButtonDisable ? '#444444' : '#DC3545'), width:"34px", marginLeft:"4px", padding:"2 4 4 4"}}
                             >
-                        </i>
-                    </Button>
+                            <i
+                                className="fa fa-times"
+                                aria-hidden="true"
+                                style={{padding: "4 4 3 4"}}
+                                onClick={ () => (doDeleteButtonDisable ? undefined : this.confirmRemoveUpload()) }
+                                >
+                            </i>
+                        </Button>
+                    }
 
-                    <Button
-                        type="button"
-                        className={"btn btn btn-sm"}
-                        style={{backgroundColor:(doDownloadButtonDisable ? '#444444' : '#007BFF'), width:"34px", marginLeft:"4px", padding:"2 4 4 4"}}
-                        >
-                        <i
-                            className="fa fa-download"
-                            aria-hidden="true"
-                            style={{padding: "4 4 3 4"}}
-                            onClick={ () => (doDownloadButtonDisable ? undefined : this.downloadUpload()) }
+                    {
+                        (!doDownloadButtonHide) &&
+                        <Button
+                            type="button"
+                            className={"btn btn btn-sm"}
+                            style={{backgroundColor:(doDownloadButtonDisable ? '#444444' : '#007BFF'), width:"34px", marginLeft:"4px", padding:"2 4 4 4"}}
                             >
-                        </i>
-                    </Button>
+                            <i
+                                className="fa fa-download"
+                                aria-hidden="true"
+                                style={{padding: "4 4 3 4"}}
+                                onClick={ () => (doDownloadButtonDisable ? undefined : this.downloadUpload()) }
+                                >
+                            </i>
+                        </Button>
+                    }
 
                 </div>
             </div>
@@ -684,6 +692,7 @@ class UploadsPage extends React.Component {
         const uploadButtonAccess = ["MANAGER", "UPLOAD"];
         let hasUploadAccess = uploadButtonAccess.includes(userFleetAccess);
         let doUploadButtonDisable = (!hasUploadAccess);
+        let doUploadButtonHide = (!hasUploadAccess);
 
         return (
 
@@ -691,25 +700,30 @@ class UploadsPage extends React.Component {
                 <SignedInNavbar activePage="uploads" waitingUserCount={waitingUserCount} fleetManager={fleetManager} unconfirmedTailsCount={unconfirmedTailsCount} modifyTailsAccess={modifyTailsAccess} plotMapHidden={plotMapHidden}/>
 
                 <div className="p-1">
-                    <input id ="upload-file-input" type="file" style={hiddenStyle} />
 
-                    <div className="card mb-1 border-secondary">
-                        <div className="p-2">
-                            {
-                                this.state.pending_uploads.length > 0
-                                    ? ( <button className="btn btn-sm btn-info pr-2" disabled>Pending Uploads</button> )
-                                    : ""
-                            }
-                            <button
-                                id="upload-flights-button"
-                                className="btn btn-primary btn-sm float-right"
-                                onClick={() => (doUploadButtonDisable ? undefined : this.triggerInput())}
-                                style={{backgroundColor: doUploadButtonDisable ?  '#444444' : '#007BFF'}}
-                                >
-                                <i className="fa fa-upload"/>Upload Flights
-                            </button>
+                    <input id ="upload-file-input" type="file" style={hiddenStyle} />
+                    {
+                        (!doUploadButtonHide) &&
+                        <div className="card mb-1 border-secondary">
+                            <div className="p-2">
+                                {
+                                    this.state.pending_uploads.length > 0
+                                        ? ( <button className="btn btn-sm btn-info pr-2" disabled>Pending Uploads</button> )
+                                        : ""
+                                }
+
+                                <button
+                                    id="upload-flights-button"
+                                    className="btn btn-primary btn-sm float-right"
+                                    onClick={() => (doUploadButtonDisable ? undefined : this.triggerInput())}
+                                    style={{backgroundColor: doUploadButtonDisable ?  '#444444' : '#007BFF'}}
+                                    >
+                                    <i className="fa fa-upload"/>Upload Flights
+                                </button>
+                                
+                            </div>
                         </div>
-                    </div>
+                    }
 
                     {
                         this.state.pending_uploads.map((uploadInfo, index) => {

--- a/src/main/javascript/uploads.js
+++ b/src/main/javascript/uploads.js
@@ -20,7 +20,9 @@ var chunkSize = 2 * 1024 * 1024; //2MB
 class Upload extends React.Component {
     constructor(props) {
         super(props);
-        this.isFleetManager = this.props.isFleetManager;
+        this.state = {
+            userFleetAccess : this.props.userFleetAccess
+        }
     }
 
     componentDidMount() {
@@ -87,6 +89,15 @@ class Upload extends React.Component {
     }
 
     render() {
+
+
+        let user = "";
+        let fleetName = "";
+        let fleetUsers = []
+        if (typeof this.state.user != 'undefined')
+            user = this.state.user;
+
+
         let uploadInfo = this.props.uploadInfo;
 
         let progressSize = uploadInfo.progressSize;
@@ -154,8 +165,19 @@ class Upload extends React.Component {
         console.log("uploadInfo:");
         console.log(uploadInfo);
 
-        //Disable Download/Delete buttons while Hashing/Uploading or if not a Fleet Manager
-        let doButtonDisplay = (this.isFleetManager && status!="HASHING" && status!="UPLOADING");
+        //Check if ALL buttons should be disabled
+        const buttonDisableStates = ["HASHING", "UPLOADING"];
+        let doButtonsDisable = buttonDisableStates.includes(status);
+
+        //Disable Delete buttons with no Upload Access
+        const deleteButtonAccess = ["MANAGER", "UPLOAD"];
+        let hasDeleteAccess = deleteButtonAccess.includes(this.state.userFleetAccess);
+        let doDeleteButtonDisable = (doButtonsDisable || !hasDeleteAccess);
+
+        //Disable Delete buttons with no View Access
+        const downloadButtonAccess = ["MANAGER", "UPLOAD", "VIEW"];
+        let hasDownloadAccess = downloadButtonAccess.includes(this.state.userFleetAccess);
+        let doDownloadButtonDisable = (doButtonsDisable || !hasDownloadAccess);
 
         return (
             <div className="m-1">
@@ -170,13 +192,13 @@ class Upload extends React.Component {
                     <Button
                         type="button"
                         className={"btn btn-danger btn-sm"}
-                        style={{backgroundColor:(doButtonDisplay ? '#DC3545' : '#444444'), width:"34px", marginLeft:"4px", padding:"2 4 4 4"}}
+                        style={{backgroundColor:(doDeleteButtonDisable ? '#444444' : '#DC3545'), width:"34px", marginLeft:"4px", padding:"2 4 4 4"}}
                         >
                         <i
                             className="fa fa-times"
                             aria-hidden="true"
                             style={{padding: "4 4 3 4"}}
-                            onClick={ () => (doButtonDisplay ? this.confirmRemoveUpload() : undefined) }
+                            onClick={ () => (doDeleteButtonDisable ? undefined : this.confirmRemoveUpload()) }
                             >
                         </i>
                     </Button>
@@ -184,13 +206,13 @@ class Upload extends React.Component {
                     <Button
                         type="button"
                         className={"btn btn btn-sm"}
-                        style={{backgroundColor:(doButtonDisplay ? '#007BFF' : '#444444'), width:"34px", marginLeft:"4px", padding:"2 4 4 4"}}
+                        style={{backgroundColor:(doDownloadButtonDisable ? '#444444' : '#007BFF'), width:"34px", marginLeft:"4px", padding:"2 4 4 4"}}
                         >
                         <i
                             className="fa fa-download"
                             aria-hidden="true"
                             style={{padding: "4 4 3 4"}}
-                            onClick={ () => (doButtonDisplay ? this.downloadUpload() : undefined) }
+                            onClick={ () => (doDownloadButtonDisable ? undefined : this.downloadUpload()) }
                             >
                         </i>
                     </Button>
@@ -212,6 +234,7 @@ class UploadsPage extends React.Component {
         super(props);
 
         this.state = {
+            user : this.props.user,
             uploads : this.props.uploads,
             pending_uploads : this.props.pending_uploads,
 
@@ -224,7 +247,7 @@ class UploadsPage extends React.Component {
 
     getMD5Hash(file, onFinish, uploadsPage) {
 
-        // console.log(`[EX] Processing MD5 Hash for File: "${file.name}" at position ${file.position}`);
+        // console.log(`Processing MD5 Hash for File: "${file.name}" at position ${file.position}`);
 
         var blobSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice,
             chunkSize = 2097152,                             // Read in chunks of 2MB
@@ -267,7 +290,7 @@ class UploadsPage extends React.Component {
                     state.pending_uploads[file.position].progressSize = 0;
                     state.pending_uploads[file.position].status = "UPLOADING";
 
-                    // console.log(`[EX] File with identifier "${file.identifier}" at position ${file.position} transitioning to new status... "${statusInitial}" -> "UPLOADING"`);
+                    // console.log(`File with identifier "${file.identifier}" at position ${file.position} transitioning to new status... "${statusInitial}" -> "UPLOADING"`);
                     uploadsPage.setState(state);
 
                     onFinish(spark.end());
@@ -292,7 +315,7 @@ class UploadsPage extends React.Component {
 
     startUpload(file) {
 
-        // console.log(`[EX] Starting upload of file: ${file}`);
+        // console.log(`Starting upload of file: ${file}`);
 
         //different versions of firefox have different field names
         var filename = file.webkitRelativePath || file.fileName || file.name;
@@ -323,7 +346,7 @@ class UploadsPage extends React.Component {
             xhr.open('POST', '/protected/new_upload');
             xhr.onload = function() {
                 
-                // console.log("[EX] New upload response: " + xhr.responseText);
+                // console.log("New upload response: " + xhr.responseText);
                 var response = JSON.parse(xhr.responseText);
 
                 var filename = (file.webkitRelativePath || file.fileName || file.name);
@@ -374,7 +397,7 @@ class UploadsPage extends React.Component {
         let alreadyExists = false;
         for (var i = 0; i < pendingUploads.length; i++) {
 
-            // console.log(`[EX] Pending Upload Identifier (${i}): ${pendingUploads[i].identifier} /// Current Upload Identifier: ${identifier}`);
+            // console.log(`Pending Upload Identifier (${i}): ${pendingUploads[i].identifier} /// Current Upload Identifier: ${identifier}`);
 
             //Testing Matching Identifiers
             if (pendingUploads[i].identifier == identifier) {
@@ -422,7 +445,7 @@ class UploadsPage extends React.Component {
         this.state.pending_uploads = pendingUploads;
 
         // let uploadStringMap = this.state.pending_uploads.map(function(uploadItem) { return `(${uploadItem.identifier},${uploadItem.position})` });
-        // console.log(`[EX] Updated Pending Uploads after adding new file with identifier "${file.identifier}": [${uploadStringMap}]`);
+        // console.log(`Updated Pending Uploads after adding new file with identifier "${file.identifier}": [${uploadStringMap}]`);
 
         if (this.state.numberPages == 0) {
             this.state.numberPages = 1;
@@ -441,7 +464,7 @@ class UploadsPage extends React.Component {
             let pending_uploads = this.state.pending_uploads;
 
             // let uploadStringMap = this.state.pending_uploads.map(function(uploadItem) { return uploadItem.identifier });
-            // console.log(`[EX] Removing a *pending* file upload! Original State: [${uploadStringMap}]`);
+            // console.log(`Removing a *pending* file upload! Original State: [${uploadStringMap}]`);
 
             pending_uploads.splice(file.position, 1);
             for (var i = 0; i < pending_uploads.length; i++) {
@@ -451,7 +474,7 @@ class UploadsPage extends React.Component {
             this.state.pending_uploads = pending_uploads;
 
             // uploadStringMap = this.state.pending_uploads.map(function(uploadItem) { return uploadItem.identifier; });
-            // console.log(`[EX] Removing a *pending* file upload! New State: [${uploadStringMap}]`);
+            // console.log(`Removing a *pending* file upload! New State: [${uploadStringMap}]`);
 
             this.setState( this.state );
         }
@@ -465,7 +488,7 @@ class UploadsPage extends React.Component {
             let uploads = this.state.uploads;
 
             // let uploadStringMap = this.state.uploads.map(function(uploadItem) { return uploadItem.identifier });
-            // console.log(`[EX] Removing a file upload! Original State: [${uploadStringMap}]`);
+            // console.log(`Removing a file upload! Original State: [${uploadStringMap}]`);
 
             uploads.splice(file.position, 1);
             for (var i = 0; i < uploads.length; i++) {
@@ -476,7 +499,7 @@ class UploadsPage extends React.Component {
             this.state.uploads = uploads;
 
             // uploadStringMap = this.state.uploads.map(function(uploadItem) { return uploadItem.identifier });
-            // console.log(`[EX] Removing a file upload! New State: [${uploadStringMap}]`);
+            // console.log(`Removing a file upload! New State: [${uploadStringMap}]`);
 
             this.setState( this.state );
         }
@@ -484,10 +507,10 @@ class UploadsPage extends React.Component {
 
     updateUpload(uploadInfo) {
 
-        // console.log(`[EX] Updating Upload Info: ${uploadInfo.identifier}`);
+        // console.log(`Updating Upload Info: ${uploadInfo.identifier}`);
 
         // let uploadStringMap = this.state.pending_uploads.map(function(uploadItem) { return `(${uploadItem.identifier},${uploadItem.position})` });
-        // console.log(`[EX] Before... : ${uploadStringMap}`);
+        // console.log(`Before... : ${uploadStringMap}`);
 
 
         var file = uploadInfo.file;
@@ -507,7 +530,7 @@ class UploadsPage extends React.Component {
         this.state.pending_uploads[uploadInfo.position] = uploadInfo;
 
         //uploadStringMap = this.state.pending_uploads.map(function(uploadItem) { return `(${uploadItem.identifier},${uploadItem.position})` });
-        // console.log(`[EX] After... : ${uploadStringMap}`);
+        // console.log(`After... : ${uploadStringMap}`);
 
         this.setState( this.state );
 
@@ -652,9 +675,16 @@ class UploadsPage extends React.Component {
             display : "none"
         };
 
-        //Disable Upload Flights button if not a Fleet Manager
-        let doButtonDisplay = (fleetManager);
-        
+        //Get User Fleet Access
+        let userFleetAccess = "VIEW";
+        if (typeof this.state.user != 'undefined')
+            userFleetAccess = this.state.user.fleetAccess.accessType;
+
+        //Disable Upload buttons with no Upload Access
+        const uploadButtonAccess = ["MANAGER", "UPLOAD"];
+        let hasUploadAccess = uploadButtonAccess.includes(userFleetAccess);
+        let doUploadButtonDisable = (!hasUploadAccess);
+
         return (
 
             <div>
@@ -673,10 +703,10 @@ class UploadsPage extends React.Component {
                             <button
                                 id="upload-flights-button"
                                 className="btn btn-primary btn-sm float-right"
-                                onClick={() => (doButtonDisplay ? this.triggerInput() : undefined)}
-                                style={{backgroundColor: doButtonDisplay ? '#007BFF' : '#444444'}}
+                                onClick={() => (doUploadButtonDisable ? undefined : this.triggerInput())}
+                                style={{backgroundColor: doUploadButtonDisable ?  '#444444' : '#007BFF'}}
                                 >
-                                <i className="fa fa-upload"></i> Upload Flights
+                                <i className="fa fa-upload"/>Upload Flights
                             </button>
                         </div>
                     </div>
@@ -685,23 +715,24 @@ class UploadsPage extends React.Component {
                         this.state.pending_uploads.map((uploadInfo, index) => {
 
                             // let uploadStringMap = this.state.pending_uploads.map(function(uploadItem) { return `(${uploadItem.identifier},${uploadItem.position})` });
-                            // console.log(`[EX] Previewing all Pending Uploads: ${uploadStringMap}`);
-                            // console.log(`[EX] Delivering new Upload Info with identifier "${uploadInfo.identifier}" and position "${uploadInfo.position}" at index ${index}`);
+                            // console.log(`Previewing all Pending Uploads: ${uploadStringMap}`);
+                            // console.log(`Delivering new Upload Info with identifier "${uploadInfo.identifier}" and position "${uploadInfo.position}" at index ${index}`);
 
                             //uploadInfo.position = index;
                             return (
                                 <Upload
-                                    isFleetManager={fleetManager}
-                                    uploadInfo={ uploadInfo }
-                                    key={ uploadInfo.identifier }
-                                    removeUpload={ (uploadInfo) => { this.removePendingUpload(uploadInfo); } }
-                                    />
+                                    userFleetAccess={userFleetAccess}
+                                    uploadInfo={uploadInfo}
+                                    key={uploadInfo.identifier}
+                                    removeUpload={(uploadInfo) => {this.removePendingUpload(uploadInfo);}}
+                                />
                             );
                         })
                     }
 
                     <Paginator
                         submitFilter={() => {this.submitFilter();}}
+                        userFleetAccess={userFleetAccess}
                         items={this.state.uploads}
                         itemName="uploads"
                         currentPage={this.state.currentPage}
@@ -719,13 +750,19 @@ class UploadsPage extends React.Component {
                         this.state.uploads.map((uploadInfo, index) => {
                             uploadInfo.position = index;
                             return (
-                                <Upload isFleetManager={fleetManager} uploadInfo={uploadInfo} key={uploadInfo.identifier} removeUpload={(uploadInfo) => {this.removeUpload(uploadInfo);}} />
+                                <Upload
+                                    userFleetAccess={userFleetAccess}
+                                    uploadInfo={uploadInfo}
+                                    key={uploadInfo.identifier}
+                                    removeUpload={(uploadInfo) => {this.removeUpload(uploadInfo);}}
+                                />
                             );
                         })
                     }
 
                     <Paginator
                         submitFilter={() => {this.submitFilter();}}
+                        userFleetAccess={userFleetAccess}
                         items={this.state.uploads}
                         itemName="uploads"
                         currentPage={this.state.currentPage}
@@ -748,6 +785,6 @@ class UploadsPage extends React.Component {
 
 
 var uploadsPage = ReactDOM.render(
-    <UploadsPage uploads={uploads} pending_uploads={pending_uploads} numberPages={numberPages} currentPage={currentPage}/>,
+    <UploadsPage user={user} uploads={uploads} pending_uploads={pending_uploads} numberPages={numberPages} currentPage={currentPage}/>,
     document.querySelector('#uploads-page')
 );

--- a/src/main/javascript/uploads.js
+++ b/src/main/javascript/uploads.js
@@ -20,9 +20,6 @@ var chunkSize = 2 * 1024 * 1024; //2MB
 class Upload extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {
-            userFleetAccess : this.props.userFleetAccess
-        }
     }
 
     componentDidMount() {
@@ -89,14 +86,6 @@ class Upload extends React.Component {
     }
 
     render() {
-
-
-        let user = "";
-        let fleetName = "";
-        let fleetUsers = []
-        if (typeof this.state.user != 'undefined')
-            user = this.state.user;
-
 
         let uploadInfo = this.props.uploadInfo;
 
@@ -170,14 +159,12 @@ class Upload extends React.Component {
         let doButtonsDisable = buttonDisableStates.includes(status);
 
         //Disable Delete buttons with no Upload Access
-        const deleteButtonAccess = ["MANAGER", "UPLOAD"];
-        let hasDeleteAccess = deleteButtonAccess.includes(this.state.userFleetAccess);
+        let hasDeleteAccess = (isUploader);
         let doDeleteButtonDisable = (doButtonsDisable || !hasDeleteAccess);
         let doDeleteButtonHide = (!hasDeleteAccess);
 
         //Disable Delete buttons with no View Access
-        const downloadButtonAccess = ["MANAGER", "UPLOAD", "VIEW"];
-        let hasDownloadAccess = downloadButtonAccess.includes(this.state.userFleetAccess);
+        let hasDownloadAccess = true;
         let doDownloadButtonDisable = (doButtonsDisable || !hasDownloadAccess);
         let doDownloadButtonHide = (!hasDownloadAccess);
 
@@ -242,7 +229,6 @@ class UploadsPage extends React.Component {
         super(props);
 
         this.state = {
-            user : this.props.user,
             uploads : this.props.uploads,
             pending_uploads : this.props.pending_uploads,
 
@@ -683,16 +669,9 @@ class UploadsPage extends React.Component {
             display : "none"
         };
 
-        //Get User Fleet Access
-        let userFleetAccess = "VIEW";
-        if (typeof this.state.user != 'undefined')
-            userFleetAccess = this.state.user.fleetAccess.accessType;
-
         //Disable Upload buttons with no Upload Access
-        const uploadButtonAccess = ["MANAGER", "UPLOAD"];
-        let hasUploadAccess = uploadButtonAccess.includes(userFleetAccess);
-        let doUploadButtonDisable = (!hasUploadAccess);
-        let doUploadButtonHide = (!hasUploadAccess);
+        let doUploadButtonDisable = (!isUploader);
+        let doUploadButtonHide = (!isUploader);
 
         return (
 
@@ -735,7 +714,6 @@ class UploadsPage extends React.Component {
                             //uploadInfo.position = index;
                             return (
                                 <Upload
-                                    userFleetAccess={userFleetAccess}
                                     uploadInfo={uploadInfo}
                                     key={uploadInfo.identifier}
                                     removeUpload={(uploadInfo) => {this.removePendingUpload(uploadInfo);}}
@@ -746,7 +724,6 @@ class UploadsPage extends React.Component {
 
                     <Paginator
                         submitFilter={() => {this.submitFilter();}}
-                        userFleetAccess={userFleetAccess}
                         items={this.state.uploads}
                         itemName="uploads"
                         currentPage={this.state.currentPage}
@@ -765,7 +742,6 @@ class UploadsPage extends React.Component {
                             uploadInfo.position = index;
                             return (
                                 <Upload
-                                    userFleetAccess={userFleetAccess}
                                     uploadInfo={uploadInfo}
                                     key={uploadInfo.identifier}
                                     removeUpload={(uploadInfo) => {this.removeUpload(uploadInfo);}}
@@ -776,7 +752,6 @@ class UploadsPage extends React.Component {
 
                     <Paginator
                         submitFilter={() => {this.submitFilter();}}
-                        userFleetAccess={userFleetAccess}
                         items={this.state.uploads}
                         itemName="uploads"
                         currentPage={this.state.currentPage}
@@ -799,6 +774,6 @@ class UploadsPage extends React.Component {
 
 
 var uploadsPage = ReactDOM.render(
-    <UploadsPage user={user} uploads={uploads} pending_uploads={pending_uploads} numberPages={numberPages} currentPage={currentPage}/>,
+    <UploadsPage uploads={uploads} pending_uploads={pending_uploads} numberPages={numberPages} currentPage={currentPage}/>,
     document.querySelector('#uploads-page')
 );

--- a/src/main/resources/public/templates/uploads.html
+++ b/src/main/resources/public/templates/uploads.html
@@ -9,6 +9,7 @@
 
     <script>
         var plotMapHidden = true;
+        {{{user_js}}}
         {{{numPages_js}}}
         {{{index_js}}}
         {{{navbar_js}}}


### PR DESCRIPTION
Fixed/updated the behavior for the following on the Uploads page:

**VIEW ACCESS:**
```
* Upload Button   -> Disabled ❌
* Delete Button   -> Disabled ❌
* Download Button -> Enabled  ✅
```

**UPLOAD & MANAGER ACCESS:**
```
* Upload Button   -> Enabled  ✅
* Delete Button   -> Enabled  ✅
* Download Button -> Enabled  ✅
```


08/26/24:
- The Upload/Download buttons will now be completely hidden for users with View access. Functionality to disable/gray-out certain buttons is kept for when the delete and download buttons during an in-progress upload, and for posterity for the upload button.
- Now uses information injected by Navbar's getJavascript to determine if the Upload/Delete buttons can be displayed (existing fix merged from commit on main)