### PR TITLE
Pass existing connections into email functions when possible

### DIFF
--- a/src/main/java/org/ngafid/ProcessUpload.java
+++ b/src/main/java/org/ngafid/ProcessUpload.java
@@ -238,7 +238,7 @@ public class ProcessUpload {
 
             String subject = "NGAFID processing upload '" + filename + "' started at " + formattedStartDateTime;
             String body = subject;
-            SendEmail.sendEmail(recipients, bccRecipients, subject, body, EmailType.UPLOAD_PROCESS_START);
+            SendEmail.sendEmail(recipients, bccRecipients, subject, body, EmailType.UPLOAD_PROCESS_START, connection);
 
             upload.reset(connection);
             System.out.println("upload was reset!\n\n");
@@ -269,7 +269,7 @@ public class ProcessUpload {
 
             //  sendMonthlyFlightsUpdate(fleetId);    [EX] Disabling ALL monthly flight update calls for now!
 
-            uploadProcessedEmail.sendEmail();
+            uploadProcessedEmail.sendEmail(connection);
 
         } catch (SQLException e) {
             System.err.println("ERROR processing upload: " + e);

--- a/src/main/java/org/ngafid/SendEmail.java
+++ b/src/main/java/org/ngafid/SendEmail.java
@@ -155,7 +155,7 @@ public class SendEmail {
     }
 
 
-    public static void freeExpiredUnsubscribeTokens() {
+    public static void freeExpiredUnsubscribeTokens(Connection connection) throws SQLException {
         
         Calendar calendar = Calendar.getInstance();
         java.sql.Date currentDate = new java.sql.Date(calendar.getTimeInMillis());
@@ -169,7 +169,7 @@ public class SendEmail {
         }
         lastTokenFree.setTime(currentDate.getTime());
 
-        try (Connection connection = Database.getConnection()) {
+        try {
 
             String query = "DELETE FROM email_unsubscribe_tokens WHERE expiration_date < ?";
             PreparedStatement preparedStatement = connection.prepareStatement(query);
@@ -178,13 +178,16 @@ public class SendEmail {
 
             LOG.info("Freed expired email unsubscribe tokens");
 
+        } catch (SQLException e) {
+            LOG.severe("(SQL Exception) Failed to free expired email unsubscribe tokens: "+e.getMessage());
+            throw e;
         } catch (Exception e) {
-            LOG.severe("Failed to free expired email unsubscribe tokens");
+            LOG.severe("(Non-SQL Exception) Failed to free expired email unsubscribe tokens: "+e.getMessage());
         }
 
     }
 
-    private static String generateUnsubscribeToken(String recipientEmail, int userID) {
+    private static String generateUnsubscribeToken(String recipientEmail, int userID, Connection connection) throws SQLException {
         
         //Generate a random string
         String token = UUID.randomUUID().toString().replace("-", "");        
@@ -193,7 +196,7 @@ public class SendEmail {
         calendar.add(Calendar.MONTH, EMAIL_UNSUBSCRIBE_TOKEN_EXPIRATION_MONTHS);
         java.sql.Date expirationDate = new java.sql.Date(calendar.getTimeInMillis());
 
-        try (Connection connection = Database.getConnection()) {
+        try {
 
             String query = "INSERT INTO email_unsubscribe_tokens (token, user_id, expiration_date) VALUES (?, ?, ?)";
             PreparedStatement preparedStatement = connection.prepareStatement(query);
@@ -202,8 +205,11 @@ public class SendEmail {
             preparedStatement.setDate(3, expirationDate);
             preparedStatement.execute();
 
+        } catch (SQLException e) {
+            LOG.severe("(SQL Exception) Failed to generate token for email recipient: "+recipientEmail+": "+e.getMessage());
+            throw e;
         } catch (Exception e) {
-            LOG.severe("Failed to generate token for email recipient: "+recipientEmail);
+            LOG.severe("(Non-SQL Exception) Failed to generate token for email recipient: "+recipientEmail+": "+e.getMessage());
         }
 
         //Log the token's expiration date
@@ -229,10 +235,26 @@ public class SendEmail {
      * @param body - body of the email
      */
     public static void sendAdminEmails(String subject, String body, EmailType emailType) {
-        sendEmail(adminEmails, new ArrayList<>(), subject, body, emailType);
+        
+        try {
+            sendEmail(adminEmails, new ArrayList<>(), subject, body, emailType);
+        }
+        catch(SQLException e) {
+            LOG.severe("(SQL Exception) Failed to send admin email: "+e.getMessage());
+        }
     }
 
-    public static void sendEmail(ArrayList<String> toRecipients, ArrayList<String> bccRecipients, String subject, String body, EmailType emailType) {
+    public static void sendEmail(ArrayList<String> toRecipients, ArrayList<String> bccRecipients, String subject, String body, EmailType emailType) throws SQLException {
+
+        //Send the email with no existing connection
+        try (Connection connection = Database.getConnection()) {
+            LOG.info("Sending an email with a fresh SQL connection");
+            sendEmail(toRecipients, bccRecipients, subject, body, emailType, connection);
+        }
+
+    }
+
+    public static void sendEmail(ArrayList<String> toRecipients, ArrayList<String> bccRecipients, String subject, String body, EmailType emailType, Connection connection) throws SQLException {
 
         SMTPAuthenticator auth = new SMTPAuthenticator(username, password);
 
@@ -242,7 +264,7 @@ public class SendEmail {
         }
 
         //Attempt to free expired tokens
-        freeExpiredUnsubscribeTokens();
+        freeExpiredUnsubscribeTokens(connection);
 
         //System.out.println(String.format("Username: %s, PW: %s", username, password));
 
@@ -312,7 +334,7 @@ public class SendEmail {
                             int userID = UserEmailPreferences.getUserIDFromEmail(toRecipient);
 
                             //Generate a token for the user to unsubscribe
-                            String token = generateUnsubscribeToken(toRecipient, userID);
+                            String token = generateUnsubscribeToken(toRecipient, userID, connection);
                             String unsubscribeURL = unsubscribeURLTemplate.replace("__ID__", Integer.toString(userID)).replace("__TOKEN__", token);
 
                             //Embed the Unsubscribe URL at the top of the email body

--- a/src/main/java/org/ngafid/UploadProcessedEmail.java
+++ b/src/main/java/org/ngafid/UploadProcessedEmail.java
@@ -1,5 +1,8 @@
 package org.ngafid;
 
+import java.sql.SQLException;
+import java.sql.Connection;
+
 import java.util.ArrayList;
 import java.util.TreeSet;
 import java.util.TreeMap;
@@ -7,6 +10,9 @@ import java.util.TreeMap;
 import org.ngafid.accounts.EmailType;
 
 import java.util.logging.Logger;
+
+
+
 
 public class UploadProcessedEmail {
 
@@ -262,7 +268,7 @@ public class UploadProcessedEmail {
     }
 
 
-    public void sendEmail() {
+    public void sendEmail(Connection connection) throws SQLException {
 
         StringBuilder body = new StringBuilder();
 
@@ -310,6 +316,6 @@ public class UploadProcessedEmail {
 
         body.append("</body></html>");
 
-        SendEmail.sendEmail(recipients, bccRecipients, subject, body.toString(), EmailType.IMPORT_PROCESSED_RECEIPT);
+        SendEmail.sendEmail(recipients, bccRecipients, subject, body.toString(), EmailType.IMPORT_PROCESSED_RECEIPT, connection);
     }
 }

--- a/src/main/java/org/ngafid/accounts/User.java
+++ b/src/main/java/org/ngafid/accounts/User.java
@@ -875,7 +875,7 @@ public class User {
         body.append("<p> Password Reset Link : <a href=" + resetPassswordURL + ">Reset Password</a></p><br>");
         body.append("</body></html>");
         ArrayList<String> bccRecipients = new ArrayList<>();
-        SendEmail.sendEmail(recipients, bccRecipients,"NGAFID Password Reset Information", body.toString(), EmailType.PASSWORD_RESET);
+        SendEmail.sendEmail(recipients, bccRecipients,"NGAFID Password Reset Information", body.toString(), EmailType.PASSWORD_RESET, connection);
     }
 
     public void updateLastLoginTimeStamp(Connection connection) throws SQLException {

--- a/src/main/java/org/ngafid/flights/AirSync.java
+++ b/src/main/java/org/ngafid/flights/AirSync.java
@@ -61,12 +61,12 @@ public class AirSync {
      *
      * @param message the message that needs to be sent
      */
-    public static void sendAdminCrashNotification(String message) {
+    public static void sendAdminCrashNotification(String message) throws SQLException {
         String NGAFID_ADMIN_EMAILS = System.getenv("NGAFID_ADMIN_EMAILS");
         ArrayList<String> adminEmails = new ArrayList<String>(Arrays.asList(NGAFID_ADMIN_EMAILS.split(";")));
 
         ArrayList<String> bccRecipients = new ArrayList<String>();
-        SendEmail.sendEmail(adminEmails, bccRecipients, "CRITICAL: AirSync Daemon Exception!", message, EmailType.AIRSYNC_DAEMON_CRASH);
+        SendEmail.sendEmail(adminEmails, bccRecipients, "CRITICAL: AirSync Daemon Exception!", message, EmailType.AIRSYNC_DAEMON_CRASH, connection);
     }
 
     /**


### PR DESCRIPTION
Supplies existing SQL connections to the SendEmail functions to avoid possible issues with the functions used for the generation and freeing of unsubscribe tokens (which would require an additional connection otherwise).