### PR TITLE
Orange/Blue Graph Color Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ db/db_info.php
 db/db_info
 email_info.txt
 package-lock.json
-data/archive/*
+data/*

--- a/src/main/javascript/summary_page.js
+++ b/src/main/javascript/summary_page.js
@@ -165,6 +165,7 @@ export default class SummaryPage extends React.Component {
     }
     
     displayPlots(selectedAirframe) {
+        
         var countData = [];
         var percentData = [];
     
@@ -206,11 +207,10 @@ export default class SummaryPage extends React.Component {
             value.y = value.names;
             value.type = "bar";
             value.orientation = "h";
-            //value.hoverinfo = "text";
     
             //don"t add airframes to the count plot that the fleet doesn"t have
             if (airframes.indexOf(value.airframeName) >= 0)
-                countData.unshift(value);
+                countData.push(value);
 
             value.x = value.aggregateTotalEventsCounts;
             
@@ -282,11 +282,12 @@ export default class SummaryPage extends React.Component {
     
             }
         }
-    
+
+        
+
         var countLayout = {
             title : "Event Counts",
             barmode: "stack",
-            traceorder: "reversed",
             //autosize: false,
             //width: 500,
             height: 750,
@@ -296,9 +297,12 @@ export default class SummaryPage extends React.Component {
                 b: 50,
                 t: 50,
                 pad: 4
+            },
+            legend: { 
+                traceorder: "normal"
             }
         };
-    
+
         var percentLayout = {
             title : "Percentage of Flights With Event",
             //autosize: false,

--- a/src/main/javascript/summary_page.js
+++ b/src/main/javascript/summary_page.js
@@ -193,8 +193,14 @@ export default class SummaryPage extends React.Component {
         };
     
         for (let [key, value] of Object.entries(this.state.eventCounts)) {
-            if (value.airframeName === "Garmin Flight Display") continue;
-            if (selectedAirframe !== value.airframeName && selectedAirframe !== "All Airframes") continue;
+
+            //Airframe name is 'Garmin Flight Display', skip
+            if (value.airframeName === "Garmin Flight Display")
+                continue;
+
+            //Current airframe name is neither the selected airframe name or 'All Airframes', skip
+            if ((selectedAirframe !== value.airframeName) && (selectedAirframe !== "All Airframes"))
+                continue;
     
             value.name = value.airframeName;
             value.y = value.names;
@@ -203,13 +209,31 @@ export default class SummaryPage extends React.Component {
             //value.hoverinfo = "text";
     
             //don"t add airframes to the count plot that the fleet doesn"t have
-            if (airframes.indexOf(value.airframeName) >= 0) countData.push(value);
+            if (airframes.indexOf(value.airframeName) >= 0)
+                countData.unshift(value);
+
             value.x = value.aggregateTotalEventsCounts;
             
-            let percents = this.props.aggregate ? fleetPercents : ngafidPercents;
+            //  let percents = (this.props.aggregate ? fleetPercents : ngafidPercents);
 
             for (let i = 0; i < value.names.length; i++) {
-                //don't add airframes to the fleet percentage plot that the fleet doesn't have
+
+                /*
+                    Don't add airframes to the fleet percentage
+                    plot that the fleet doesn't have.
+                */
+
+                var index = ngafidPercents.y.indexOf(value.names[i]);
+                if (index !== -1) {
+                    ngafidPercents.flightsWithEventCounts[index] += value.aggregateFlightsWithEventCounts[i];
+                    ngafidPercents.totalFlightsCounts[index] += value.aggregateTotalFlightsCounts[i];
+                } else {
+                    let pos = ngafidPercents.y.length;
+                    ngafidPercents.y.push(value.names[i]);
+                    ngafidPercents.flightsWithEventCounts[pos] = value.aggregateFlightsWithEventCounts[i];
+                    ngafidPercents.totalFlightsCounts[pos] = value.aggregateTotalFlightsCounts[i];
+                }
+
                 if (airframes.indexOf(value.airframeName) >= 0) {
                     var index = fleetPercents.y.indexOf(value.names[i]);
                     if (index !== -1) {
@@ -223,28 +247,28 @@ export default class SummaryPage extends React.Component {
                     }
                 }
 
-                var index = ngafidPercents.y.indexOf(value.names[i]);
-                if (index !== -1) {
-                    ngafidPercents.flightsWithEventCounts[index] += value.aggregateFlightsWithEventCounts[i];
-                    ngafidPercents.totalFlightsCounts[index] += value.aggregateTotalFlightsCounts[i];
-                } else {
-                    let pos = ngafidPercents.y.length;
-                    ngafidPercents.y.push(value.names[i]);
-                    ngafidPercents.flightsWithEventCounts[pos] = value.aggregateFlightsWithEventCounts[i];
-                    ngafidPercents.totalFlightsCounts[pos] = value.aggregateTotalFlightsCounts[i];
-                }
             }
 
         }
    
+        
+        //Push fleetPercents data ('Your Fleet')
+        if (!this.props.aggregate)
+            percentData.push(fleetPercents);
+
+
+        //Push ngafidPercents data ('All Other Fleets')
         percentData.push(ngafidPercents);
-        if (!this.props.aggregate) percentData.push(fleetPercents);
+
     
-        for (let j = 0; j < percentData.length; j++) {
+        //for (let j = 0; j < percentData.length; j++) {
+        for (let j = percentData.length-1 ; j >= 0 ; j--) {
+
             let value = percentData[j];
             value.x = [];
     
             for (let i = 0; i < value.flightsWithEventCounts.length; i++) {
+            
                 value.x.push( 100.0 * parseFloat(value.flightsWithEventCounts[i]) / parseFloat(value.totalFlightsCounts[i]) );
 
     
@@ -262,6 +286,7 @@ export default class SummaryPage extends React.Component {
         var countLayout = {
             title : "Event Counts",
             barmode: "stack",
+            traceorder: "reversed",
             //autosize: false,
             //width: 500,
             height: 750,
@@ -290,7 +315,7 @@ export default class SummaryPage extends React.Component {
     
     
         var config = {responsive: true}
-    
+
         Plotly.newPlot("event-counts-plot", countData, countLayout, config);
         Plotly.newPlot("event-percents-plot", percentData, percentLayout, config);
     }

--- a/src/main/javascript/trends.js
+++ b/src/main/javascript/trends.js
@@ -363,9 +363,15 @@ class TrendsPage extends React.Component {
 
 
             for (let [airframe, value] of Object.entries(countsObject)) {
-                if (value.airframeName === "Garmin Flight Display") continue;
-                if (selectedAirframe !== value.airframeName && selectedAirframe !== "All Airframes") continue;
 
+                //Airframe name is 'Garmin Flight Display', skip
+                if (value.airframeName === "Garmin Flight Display")
+                    continue;
+
+                //Current airframe name is neither the selected airframe name or 'All Airframes', skip
+                if ((selectedAirframe !== value.airframeName) && (selectedAirframe !== "All Airframes"))
+                    continue;
+        
                 /*
                 console.log("airframes, airframeName, value:");
                 console.log(airframes);
@@ -446,7 +452,8 @@ class TrendsPage extends React.Component {
         */
 
         for (let [eventName, fleetValue] of Object.entries(eventFleetPercents)) {
-            let ngafidValue = eventNGAFIDPercents[eventName];
+
+            //Push fleet values...
             if (!this.state.aggregatePage) {
                 percentData.push(fleetValue);
                 fleetValue.x = [];
@@ -472,6 +479,9 @@ class TrendsPage extends React.Component {
                     fleetValue.hovertext.push(fixedText  + " (" + fleetValue.flightsWithEventCounts[date] + " of " + fleetValue.totalFlightsCounts[date] + " flights) : " + fleetValue.name);
                 }
             }
+
+            //Push NGAFID data...
+            let ngafidValue = eventNGAFIDPercents[eventName];
             percentData.push(ngafidValue);
             ngafidValue.x = [];
             ngafidValue.y = [];
@@ -496,7 +506,6 @@ class TrendsPage extends React.Component {
                 ngafidValue.hovertext.push(fixedText + " (" + ngafidValue.flightsWithEventCounts[date] + " of " + ngafidValue.totalFlightsCounts[date] + " flights) : " + ngafidValue.name);
             }
 
-            //console.log(ngafidValue);
         }
 
         /*


### PR DESCRIPTION
 * Changed ordering of the summary page's **Percentage of Flights With Event** markers to match the **Percentage of Flights With Event Over Time** markers on the Trends page
 
 
![image](https://github.com/user-attachments/assets/40536524-c954-4d4b-be7e-36268ade74c0)

![image](https://github.com/user-attachments/assets/f4074f0c-b25b-4836-9ab6-698626abc09f)


 ---
 
 * Changed the ordering of the summary page's **Event Counts** markers to match the _Blue -> Orange -> Green -> etc._ color ordering in the other graphs, and it will also follow the ordering of the drop-down menu
 

 
![image](https://github.com/user-attachments/assets/916c9dc9-f2ad-46a9-b152-1caa0e3d5e34)

![image](https://github.com/user-attachments/assets/311a4370-f714-4856-9c47-2f93bf9477fd)
