### PR TITLE
Updated/Distinct HTML Titles

### DIFF
--- a/src/main/resources/public/templates/aggregate.html
+++ b/src/main/resources/public/templates/aggregate.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="/css/theme-preload.css">
     <script src="/js/theme_preload-bundle.js"></script>
     
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Aggregate - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/aggregate_trends.html
+++ b/src/main/resources/public/templates/aggregate_trends.html
@@ -4,7 +4,7 @@
   <link rel="stylesheet" href="/css/theme-preload.css">
   <script src="/js/theme_preload-bundle.js"></script>
 
-  <title>The National General Aviation Flight Information Database (NGAFID)</title>
+  <title>Aggregate Trends - NGAFID</title>
 
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/airsync_imports.html
+++ b/src/main/resources/public/templates/airsync_imports.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="/css/theme-preload.css">
     <script src="/js/theme_preload-bundle.js"></script>
     
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Airsync Imports - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/airsync_uploads.html
+++ b/src/main/resources/public/templates/airsync_uploads.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="/css/theme-preload.css">
     <script src="/js/theme_preload-bundle.js"></script>
     
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Airsync Uploads - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/create_account.html
+++ b/src/main/resources/public/templates/create_account.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Create Account - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/create_event.html
+++ b/src/main/resources/public/templates/create_event.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
     
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Create Event - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/event_definitions_display.html
+++ b/src/main/resources/public/templates/event_definitions_display.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Event Definitions - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/event_statistics.html
+++ b/src/main/resources/public/templates/event_statistics.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Event Statistics - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/flight.html
+++ b/src/main/resources/public/templates/flight.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
     
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Flight - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/flights.html
+++ b/src/main/resources/public/templates/flights.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Flights - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/forgot_password.html
+++ b/src/main/resources/public/templates/forgot_password.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Forgot Password - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/home.html
+++ b/src/main/resources/public/templates/home.html
@@ -6,7 +6,8 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>NGAFID</title>
+    <!-- <title>Home - NGAFID</title> -->
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/imports.html
+++ b/src/main/resources/public/templates/imports.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Imports - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/manage_events.html
+++ b/src/main/resources/public/templates/manage_events.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Manage Events - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/manage_fleet.html
+++ b/src/main/resources/public/templates/manage_fleet.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Manage Fleet - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/preferences_page.html
+++ b/src/main/resources/public/templates/preferences_page.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Preferences - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/reset_password.html
+++ b/src/main/resources/public/templates/reset_password.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Reset Password - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/severities.html
+++ b/src/main/resources/public/templates/severities.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Event Severities - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/system_ids.html
+++ b/src/main/resources/public/templates/system_ids.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Manage Tail Numbers - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/trends.html
+++ b/src/main/resources/public/templates/trends.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Event Trends - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/ttf.html
+++ b/src/main/resources/public/templates/ttf.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Turn to Final - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/update_event.html
+++ b/src/main/resources/public/templates/update_event.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
     
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Update Event - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/update_password.html
+++ b/src/main/resources/public/templates/update_password.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Update Password - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/update_profile.html
+++ b/src/main/resources/public/templates/update_profile.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Update Profile - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/uploads.html
+++ b/src/main/resources/public/templates/uploads.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Uploads - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/waiting.html
+++ b/src/main/resources/public/templates/waiting.html
@@ -6,7 +6,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
     
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Waiting - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 

--- a/src/main/resources/public/templates/welcome.html
+++ b/src/main/resources/public/templates/welcome.html
@@ -5,7 +5,7 @@
     <script src="/js/theme_preload-bundle.js"></script>
 
 
-    <title>The National General Aviation Flight Information Database (NGAFID)</title>
+    <title>Summary - NGAFID</title>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 


### PR DESCRIPTION
Quick change to display distinct browser tab titles per page.

Changed version matches the common format of _Page Name_ - _Site Name_.

Should make navigation and testing easier, especially when multiple site tabs are open at once.

--- 

Changed: 
![image](https://github.com/user-attachments/assets/ab0beaf5-f82b-40a0-96e3-37944624f82b)


Original:
![image](https://github.com/user-attachments/assets/ebb78e5f-e6f4-44b1-8c54-3e623885719e)
