### PR TITLE
Use fa-spinner instead of ajax-loader.gif

### DIFF
--- a/src/main/resources/public/css/main.css
+++ b/src/main/resources/public/css/main.css
@@ -623,7 +623,7 @@ html, body {
     position: fixed;
     display: block;
     opacity: 0.7;
-    background-color: #fff;
+    background-color: var(--c_bg);
     z-index: 99;
     text-align: center;
 }
@@ -633,12 +633,37 @@ html, body {
     color: var(--c_text) !important;
 }
 
-#loading-image {
-    margin-left: auto;
-    margin-right: auto;
-    margin-top: 10%;
-    z-index: 100;
+
+
+@keyframes pulse {
+    0%      { transform: scale(1) rotate(0deg); }
+    50%     { transform: scale(1.5) rotate(180deg); }
+    100%    { transform: scale(1) rotate(360deg); }
 }
+@keyframes flash {
+    0%      { color: var(--c_confirm_bg); }
+    50%     { color: white; }
+    100%    { color: var(--c_confirm_bg); }
+}
+#loading-image {
+
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 200px;
+    height: 200px;
+    margin: -100px 0 0 -100px;
+
+    font-size: 200px;
+
+    scale: 0.50;
+
+    z-index: 100;
+    color: var(--c_confirm_bg);
+
+    animation: pulse 2.5s infinite linear, flash 2.5s infinite ease-in-out;
+}
+
 
 /*#endregion Loading Properties */
 

--- a/src/main/resources/public/templates/aggregate.html
+++ b/src/main/resources/public/templates/aggregate.html
@@ -24,8 +24,8 @@
 <body>
     <div id="aggregate-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/aggregate_trends.html
+++ b/src/main/resources/public/templates/aggregate_trends.html
@@ -24,8 +24,8 @@
 <body>
 <div id="trends-page"></div>
 
-<div id="loading" style="display:none">
-  <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+<div id="loading" style="display: none;">
+    <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
 </div>
 
 <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/airsync_imports.html
+++ b/src/main/resources/public/templates/airsync_imports.html
@@ -23,8 +23,8 @@
 <body>
     <div id="airsync-imports-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/airsync_uploads.html
+++ b/src/main/resources/public/templates/airsync_uploads.html
@@ -24,8 +24,8 @@
 <body>
     <div id="airsync-uploads-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/create_account.html
+++ b/src/main/resources/public/templates/create_account.html
@@ -21,8 +21,8 @@
 <body>
     <div id='navbar'></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="login-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/create_event.html
+++ b/src/main/resources/public/templates/create_event.html
@@ -25,8 +25,8 @@
 <body>
     <div id='navbar'></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/event_definitions_display.html
+++ b/src/main/resources/public/templates/event_definitions_display.html
@@ -23,8 +23,8 @@
 <body>
     <div id="event-definitions-display-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/event_statistics.html
+++ b/src/main/resources/public/templates/event_statistics.html
@@ -23,10 +23,9 @@
 <body>
     <div id="event-statistics-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
-
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>
         <div class='modal-dialog modal-lg' role='document'>
             <div id='error-modal-content'>

--- a/src/main/resources/public/templates/flight.html
+++ b/src/main/resources/public/templates/flight.html
@@ -25,8 +25,8 @@
 <body>
     <div id="flight-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/flight_display.html
+++ b/src/main/resources/public/templates/flight_display.html
@@ -23,8 +23,8 @@
 <body>
 <div id='navbar'></div>
 
-<div id="loading" style="display:none">
-    <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+<div id="loading" style="display: none;">
+    <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
 </div>
 
 <div id="login-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/flights.html
+++ b/src/main/resources/public/templates/flights.html
@@ -26,8 +26,8 @@
 
     <div id='flights-page'></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/forgot_password.html
+++ b/src/main/resources/public/templates/forgot_password.html
@@ -22,8 +22,8 @@
 
 <div id='navbar'></div>
 
-<div id="loading" style="display:none">
-    <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+<div id="loading" style="display: none;">
+    <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
 </div>
 
 <div id="login-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/home.html
+++ b/src/main/resources/public/templates/home.html
@@ -23,8 +23,8 @@
         </div>
 
         <div className="d-flex flex-row" style="overflow-y:auto; overflow-x:hidden; flex:1 1 auto">
-            <div id="loading" style="display:none">
-                <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+            <div id="loading" style="display: none;">
+                <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
             </div>
 
             <div id="login-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/imports.html
+++ b/src/main/resources/public/templates/imports.html
@@ -25,10 +25,10 @@
 <body>
     <div id="imports-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
-
+    
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>
         <div class='modal-dialog modal-lg' role='document'>
             <div id='error-modal-content'>

--- a/src/main/resources/public/templates/manage_events.html
+++ b/src/main/resources/public/templates/manage_events.html
@@ -23,8 +23,8 @@
 <body>
 <div id="manage-events-page"></div>
 
-<div id="loading" style="display:none">
-    <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+<div id="loading" style="display: none;">
+    <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
 </div>
 
 <div id="update-event-definition-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/manage_fleet.html
+++ b/src/main/resources/public/templates/manage_fleet.html
@@ -23,8 +23,8 @@
 <body>
     <div id="manage-fleet-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/preferences_page.html
+++ b/src/main/resources/public/templates/preferences_page.html
@@ -29,8 +29,8 @@
 <body>
     <div id="preferences-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/reset_password.html
+++ b/src/main/resources/public/templates/reset_password.html
@@ -20,8 +20,8 @@
 <body>
     <div id='navbar'></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="login-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/sandbox.html
+++ b/src/main/resources/public/templates/sandbox.html
@@ -23,8 +23,8 @@
 <body>
 <div id='navbar'></div>
 
-<div id="loading" style="display:none">
-    <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+<div id="loading" style="display: none;">
+    <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
 </div>
 
 <div id="login-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/severities.html
+++ b/src/main/resources/public/templates/severities.html
@@ -26,8 +26,8 @@
 <body>
     <div id="severities-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/system_ids.html
+++ b/src/main/resources/public/templates/system_ids.html
@@ -26,8 +26,8 @@
 <body>
     <div id="system-ids-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/trends.html
+++ b/src/main/resources/public/templates/trends.html
@@ -26,8 +26,8 @@
 <body>
     <div id="trends-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/ttf.html
+++ b/src/main/resources/public/templates/ttf.html
@@ -43,8 +43,8 @@
                 <a href="#" id="popup-closer"></a>
                 <div id="popup-content" class="card-body"></div>
             </div>
-            <div id="loading" style="display:none">
-                <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+            <div id="loading" style="display: none;">
+                <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
             </div>
             <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>
                 <div class='modal-dialog modal-lg' role='document'>
@@ -83,8 +83,8 @@
                 </div>
             </div>
 
-            <div id="loading" style="display:none">
-                <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+            <div id="loading" style="display: none;">
+                <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
             </div>
             <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>
                 <div class='modal-dialog modal-lg' role='document'>

--- a/src/main/resources/public/templates/turn_to_final.html
+++ b/src/main/resources/public/templates/turn_to_final.html
@@ -70,8 +70,8 @@
     <a href="#" id="popup-closer" class="ol-popup-closer"></a>
     <div id="popup-content"></div>
 </div>
-<div id="loading" style="display:none">
-    <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+<div id="loading" style="display: none;">
+    <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
 </div>
 
 <div id="login-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/update_event.html
+++ b/src/main/resources/public/templates/update_event.html
@@ -25,8 +25,8 @@
 <body>
     <div id='navbar'></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/update_password.html
+++ b/src/main/resources/public/templates/update_password.html
@@ -23,8 +23,8 @@
 <body>
     <div id="password-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/update_profile.html
+++ b/src/main/resources/public/templates/update_profile.html
@@ -23,8 +23,8 @@
 <body>
     <div id="profile-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/uploads.html
+++ b/src/main/resources/public/templates/uploads.html
@@ -26,8 +26,8 @@
 <body>
     <div id="uploads-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/waiting.html
+++ b/src/main/resources/public/templates/waiting.html
@@ -29,8 +29,8 @@
 <body style="overflow-y:hidden">
     <div id='navbar'></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>

--- a/src/main/resources/public/templates/welcome.html
+++ b/src/main/resources/public/templates/welcome.html
@@ -25,8 +25,8 @@
 <body>
     <div id="welcome-page"></div>
 
-    <div id="loading" style="display:none">
-        <img id="loading-image" src="/images/ajax-loader.gif" alt="Loading..." />
+    <div id="loading" style="display: none;">
+        <div id="loading-image" class="fa fa-spinner" alt="Loading..."></div>
     </div>
 
     <div id="error-modal" class='modal' tabIndex='-1' role='dialog'>


### PR DESCRIPTION
* Centered loading icon
* Dark mode support for transparent layer behind icon
* Replaced `ajax-loader.gif` spinner with `fa-spinner`


**Before**

![image](https://github.com/user-attachments/assets/161f2281-8269-4512-a6ea-5e9a8965c029)

**After**

![image](https://github.com/user-attachments/assets/d81df057-a241-4394-a9b4-eaf8ef4f172f)

