### PR TITLE
Trends Page Fixes (+EventDefinitions fix)

### DIFF
--- a/src/main/java/org/ngafid/events/EventDefinition.java
+++ b/src/main/java/org/ngafid/events/EventDefinition.java
@@ -125,7 +125,11 @@ public class EventDefinition {
         }.getType());
         this.severityColumnNames = GSON.fromJson(resultSet.getString(9), new TypeToken<TreeSet<String>>() {
         }.getType());
-        this.severityType = SeverityType.valueOf(resultSet.getString(10));
+
+        String severityTypeStr = resultSet.getString(10);
+        severityTypeStr = severityTypeStr.toUpperCase();
+        severityTypeStr = severityTypeStr.replaceAll(" ", "_");
+        this.severityType = SeverityType.valueOf(severityTypeStr);
 
         initializeSeverity();
     }

--- a/src/main/javascript/trends.js
+++ b/src/main/javascript/trends.js
@@ -750,8 +750,8 @@ class TrendsPage extends React.Component {
         }
 
         /*
-        console.log("percentData:");
-        console.log(percentData);
+            console.log("percentData:");
+            console.log(percentData);
         */
 
         let styles = getComputedStyle(document.documentElement);
@@ -760,11 +760,9 @@ class TrendsPage extends React.Component {
         let plotGridColor = styles.getPropertyValue("--c_plotly_grid").trim();
 
         var countLayout = {
-            title : 'Event Counts Over Time',
+            title : {text: 'Event Counts Over Time'},
             hovermode : "x unified",
-            //autosize: false,
-            //width: 500,
-            //height: 500,
+            autosize: true,
             margin: {
                 l: 50,
                 r: 50,
@@ -789,11 +787,9 @@ class TrendsPage extends React.Component {
         };
 
         var percentLayout = {
-            title : 'Percentage of Flights With Event Over Time',
+            title : {text: 'Percentage of Flights With Event Over Time'},
             hovermode : "x unified",
-            //autosize: false,
-            //width: 500,
-            //height: 500,
+            autosize: true,
             margin: {
                 l: 50,
                 r: 50,
@@ -938,7 +934,7 @@ class TrendsPage extends React.Component {
                                     exportCSV={() => this.exportCSV()}
                                 />
                             <div className="card-body" style={{padding:"0"}}>
-                                <div className="row" style={{margin:"0"}}>
+                                <div className="row" style={{margin:"0", display: "flex", height: "100%"}}>
                                     <div className="col-lg-2" style={{padding:"8 8 8 8"}}>
 
                                         {
@@ -979,9 +975,10 @@ class TrendsPage extends React.Component {
 
                                     </div>
 
-                                    <div className="col-lg-10" style={{padding:"0 0 0 8", opacity:"0.80"}}>
-                                        <div id="count-trends-plot"></div>
-                                        <div id="percent-trends-plot"></div>
+                                    <div className="col-lg-10" style={{padding:"0 0 0 8", opacity:"0.80", display:"flex", flexDirection: "column", minHeight: "85vh", flex:"1 1 auto"}}>
+                                        <div id="count-trends-plot" className="flex-fill" style={{flex: "1 1 auto", minHeight: "0", height: "100%", widhth: "100%"}}></div>
+                                        <hr style={{margin:"0", borderTop:"8px solid var(--c_card_bg)"}}></hr>
+                                        <div id="percent-trends-plot" className="flex-fill" style={{flex: "1 1 auto", minHeight: "0", height: "100%", widhth: "100%"}}></div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Fixes for stuff on the Trends page that broke (presumably because of Plotly updates)

* Manual formatting for fetched severity types in EventDefinition constructor to match enum names (i.e. capitalization and inserting underscores)
* Re-added missing plot titles to both trends plots
* Fixed bug causing the trends plots to have heights of 1,000,000+ pixels

_(Similar issues probably on Severities page, will check that too)_