### PR TITLE
Persistent Login After Restarting Webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ export NGAFID_BACKUP_DIR=<path to where backups should be stored>
 export NGAFID_BACKUP_TABLES="user fleet airframes airframe_types tails user_preferences user_preferences_metrics double_series_names stored_filters string_series_names data_type_names flight_tags sim_aircraft uploads"
 # If you don't want the webserver to send emails (exceptions, shutdowns, etc.), set this to false.
 export NGAFID_EMAIL_ENABLED=false
-# If you don't want the webserver to cache persistent sessions, requiring users to log in again after restart, set this to true
+# (Optional) To require users to log in again after restart, set this to true
 #export DISABLE_PERSISTENT_SESSIONS=true
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ export NGAFID_BACKUP_DIR=<path to where backups should be stored>
 export NGAFID_BACKUP_TABLES="user fleet airframes airframe_types tails user_preferences user_preferences_metrics double_series_names stored_filters string_series_names data_type_names flight_tags sim_aircraft uploads"
 # If you don't want the webserver to send emails (exceptions, shutdowns, etc.), set this to false.
 export NGAFID_EMAIL_ENABLED=false
+# If you don't want the webserver to cache persistent sessions, requiring users to log in again after restart, set this to true
+#export DISABLE_PERSISTENT_SESSIONS=true
 ```
 
 and run

--- a/src/main/java/org/ngafid/accounts/Fleet.java
+++ b/src/main/java/org/ngafid/accounts/Fleet.java
@@ -1,11 +1,12 @@
 package org.ngafid.accounts;
 
+import java.io.Serializable;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-public class Fleet {
+public class Fleet implements Serializable {
     private static final Logger LOG = Logger.getLogger(Fleet.class.getName());
     private final String name;
     /**

--- a/src/main/java/org/ngafid/accounts/FleetAccess.java
+++ b/src/main/java/org/ngafid/accounts/FleetAccess.java
@@ -1,5 +1,6 @@
 package org.ngafid.accounts;
 
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -8,7 +9,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
-public class FleetAccess {
+public class FleetAccess implements Serializable {
     public static final String MANAGER = "MANAGER";
     public static final String UPLOAD = "UPLOAD";
     public static final String VIEW = "VIEW";

--- a/src/main/java/org/ngafid/accounts/User.java
+++ b/src/main/java/org/ngafid/accounts/User.java
@@ -4,13 +4,14 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.ngafid.common.SendEmail;
 import org.ngafid.flights.Tails;
 
+import java.io.Serializable;
 import java.sql.*;
 import java.util.Date;
 import java.util.*;
 import java.util.logging.Logger;
 
 
-public final class User {
+public final class User implements Serializable {
     private static final Logger LOG = Logger.getLogger(User.class.getName());
 
     /**
@@ -955,6 +956,5 @@ public final class User {
             LOG.info(query.toString());
             query.executeUpdate();
         }
-
     }
 }

--- a/src/main/java/org/ngafid/accounts/UserEmailPreferences.java
+++ b/src/main/java/org/ngafid/accounts/UserEmailPreferences.java
@@ -1,11 +1,12 @@
 package org.ngafid.accounts;
 
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.logging.Logger;
 
-public class UserEmailPreferences {
+public class UserEmailPreferences implements Serializable {
 
     private static final Logger LOG = Logger.getLogger(UserEmailPreferences.class.getName());
     private static final HashMap<Integer, User> USERS = new HashMap<>();

--- a/src/main/java/org/ngafid/routes/JavalinWebServer.java
+++ b/src/main/java/org/ngafid/routes/JavalinWebServer.java
@@ -138,10 +138,13 @@ public class JavalinWebServer extends WebServer {
 
     @Override
     protected void configurePersistentSessions() {
+        app.unsafeConfig().jetty.modifyServletContextHandler(
+                handler -> handler.setSessionHandler(createSessionHandler())
+        );
 
     }
 
-    private static SessionHandler fileSessionHandler() {
+    private static SessionHandler createSessionHandler() {
         SessionHandler sessionHandler = new SessionHandler();
         SessionCache sessionCache = new DefaultSessionCache(sessionHandler);
         sessionCache.setSessionDataStore(createFileSessionDataStore());

--- a/src/main/java/org/ngafid/routes/JavalinWebServer.java
+++ b/src/main/java/org/ngafid/routes/JavalinWebServer.java
@@ -141,7 +141,6 @@ public class JavalinWebServer extends WebServer {
         app.unsafeConfig().jetty.modifyServletContextHandler(
                 handler -> handler.setSessionHandler(createSessionHandler())
         );
-
     }
 
     private static SessionHandler createSessionHandler() {

--- a/src/main/java/org/ngafid/routes/JavalinWebServer.java
+++ b/src/main/java/org/ngafid/routes/JavalinWebServer.java
@@ -157,12 +157,7 @@ public class JavalinWebServer extends WebServer {
         FileSessionDataStore fileSessionDataStore = new FileSessionDataStore();
         File baseDir = new File(System.getProperty("java.io.tmpdir"));
         File storeDir = new File(baseDir, "javalin-session-store");
-
-        if (!storeDir.mkdir()) {
-            LOG.severe("Failed to create session store directory: " + storeDir);
-            return null;
-        }
-
+        storeDir.mkdir();
         fileSessionDataStore.setStoreDir(storeDir);
         return fileSessionDataStore;
     }

--- a/src/main/java/org/ngafid/routes/JavalinWebServer.java
+++ b/src/main/java/org/ngafid/routes/JavalinWebServer.java
@@ -141,4 +141,26 @@ public class JavalinWebServer extends WebServer {
 
     }
 
+    private static SessionHandler fileSessionHandler() {
+        SessionHandler sessionHandler = new SessionHandler();
+        SessionCache sessionCache = new DefaultSessionCache(sessionHandler);
+        sessionCache.setSessionDataStore(createFileSessionDataStore());
+        sessionHandler.setSessionCache(sessionCache);
+        sessionHandler.setHttpOnly(true);
+        return sessionHandler;
+    }
+
+    private static FileSessionDataStore createFileSessionDataStore() {
+        FileSessionDataStore fileSessionDataStore = new FileSessionDataStore();
+        File baseDir = new File(System.getProperty("java.io.tmpdir"));
+        File storeDir = new File(baseDir, "javalin-session-store");
+
+        if (!storeDir.mkdir()) {
+            LOG.severe("Failed to create session store directory: " + storeDir);
+            return null;
+        }
+
+        fileSessionDataStore.setStoreDir(storeDir);
+        return fileSessionDataStore;
+    }
 }

--- a/src/main/java/org/ngafid/routes/JavalinWebServer.java
+++ b/src/main/java/org/ngafid/routes/JavalinWebServer.java
@@ -3,11 +3,16 @@ package org.ngafid.routes;
 import io.javalin.Javalin;
 import io.javalin.http.staticfiles.Location;
 import io.javalin.json.JavalinGson;
+import org.eclipse.jetty.server.session.DefaultSessionCache;
+import org.eclipse.jetty.server.session.FileSessionDataStore;
+import org.eclipse.jetty.server.session.SessionCache;
+import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.ngafid.accounts.User;
 import org.ngafid.bin.WebServer;
 import org.ngafid.routes.javalin.*;
 
+import java.io.File;
 import java.util.logging.Logger;
 
 public class JavalinWebServer extends WebServer {
@@ -130,4 +135,10 @@ public class JavalinWebServer extends WebServer {
             exceptionHandler(exception);
         });
     }
+
+    @Override
+    protected void configurePersistentSessions() {
+
+    }
+
 }


### PR DESCRIPTION
By default, the webserver will cache sessions so when the server restarts, there should be no need to log back in, unless the user intentionally logs out. This can be opted out of by adding `export DISABLE_PERSISTENT_SESSIONS=true` as an environment variable