### PR TITLE
Support for database access in unit tests.

### DIFF
--- a/ngafid-core/src/main/java/org/ngafid/core/accounts/Fleet.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/accounts/Fleet.java
@@ -3,6 +3,7 @@ package org.ngafid.core.accounts;
 import java.io.Serializable;
 import java.sql.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -192,7 +193,7 @@ public class Fleet implements Serializable {
     }
 
     /**
-     * Populates the list of users with access to this fleet
+     * Populates the list of users with access to this fleet, except for user with id `populatorId`
      *
      * @param connection  is a connection to the mysql database.
      * @param populatorId is the id of the user whose populating the list of user
@@ -244,5 +245,9 @@ public class Fleet implements Serializable {
 
     public String toString() {
         return "Fleet id: " + this.getId() + " name: " + this.getName() + ";";
+    }
+
+    public List<User> getUsers() {
+        return Collections.unmodifiableList(users);
     }
 }

--- a/ngafid-core/src/main/java/org/ngafid/core/accounts/Fleet.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/accounts/Fleet.java
@@ -160,6 +160,8 @@ public class Fleet implements Serializable {
 
                 return fleet;
             }
+        } catch (SQLIntegrityConstraintViolationException e) {
+            throw new AccountException("Cannot create name with duplicate name", e.getMessage());
         }
     }
 
@@ -249,5 +251,13 @@ public class Fleet implements Serializable {
 
     public List<User> getUsers() {
         return Collections.unmodifiableList(users);
+    }
+
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof Fleet otherFleet)) {
+            return false;
+        }
+
+        return id == otherFleet.getId() && name.equals(otherFleet.getName());
     }
 }

--- a/ngafid-core/src/test/java/org/ngafid/core/H2Database.java
+++ b/ngafid-core/src/test/java/org/ngafid/core/H2Database.java
@@ -1,0 +1,61 @@
+package org.ngafid.core;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+import liquibase.resource.DirectoryResourceAccessor;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+public class H2Database {
+
+    private static HikariDataSource CONNECTION_POOL = null;
+
+    private static final Logger LOG = Logger.getLogger(H2Database.class.getName());
+
+    static {
+        createConnectionPool();
+        try {
+            populateDatabase();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Connection getConnection() throws SQLException {
+        return CONNECTION_POOL.getConnection();
+    }
+
+    private static void createConnectionPool() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL;NON_KEYWORDS=USER,VALUE,YEAR,MONTH;DATABASE_TO_UPPER=FALSE");
+        config.setUsername("sa");
+        config.setPassword("");
+        config.setPoolName("H2Pool");
+
+        CONNECTION_POOL = new HikariDataSource(config);
+    }
+
+    private static void populateDatabase() throws SQLException {
+        try (Connection connection = CONNECTION_POOL.getConnection()) {
+            Database database = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+
+            Liquibase liquibase = new Liquibase("ngafid-db/src/test-changelog-root.xml",
+                    new DirectoryResourceAccessor(Path.of("../")), database);
+
+            liquibase.update(new Contexts());
+        } catch (LiquibaseException | FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/ngafid-core/src/test/java/org/ngafid/core/account/FleetTest.java
+++ b/ngafid-core/src/test/java/org/ngafid/core/account/FleetTest.java
@@ -1,21 +1,47 @@
 package org.ngafid.core.account;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.ngafid.core.H2Database;
+import org.ngafid.core.accounts.AccountException;
 import org.ngafid.core.accounts.Fleet;
 import org.ngafid.core.accounts.User;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class FleetTest {
-    private Fleet fleet0 = new Fleet(0, "Test Fleet");
-    private Fleet airsyncFleet = new Fleet(1, "Airsync Fleet");
+    /**
+     * A List of all test fleets in the test data
+     */
+    private static final List<Fleet> targets = List.of(new Fleet(0, "Test Fleet with ID 0"), new Fleet(1, "Test Fleet with ID 1"));
+    private static final Fleet fleet0 = new Fleet(0, "Test Fleet");
+    private static final Fleet airsyncFleet = new Fleet(1, "Airsync Fleet");
     private static User user0 = null;
 
+    private Connection connection = null;
+
+    @BeforeEach
+    public void setupConnection() {
+        try {
+            connection = H2Database.getConnection();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterEach
+    public void closeConnection() {
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @BeforeAll
     public static void setup() {
@@ -27,14 +53,66 @@ public class FleetTest {
     }
 
     @Test
-    void testConstructor() {
+    void cosntructor() {
         assertEquals(0, fleet0.getId());
         assertEquals("Test Fleet", fleet0.getName());
     }
 
     @Test
-    void testPopulateUsers() {
-        try (Connection connection = H2Database.getConnection()) {
+    void getNumberFleets() {
+        try {
+            assertEquals(2, Fleet.getNumberFleets(connection));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void get() {
+        try {
+            for (Fleet target : targets) {
+                List<Fleet> flts = List.of(
+                        Objects.requireNonNull(Fleet.get(connection, target.getId())),
+                        Objects.requireNonNull(Fleet.get(connection, target.getName()))
+                );
+                for (Fleet f : flts) {
+                    assertEquals(target.getId(), f.getId());
+                    assertEquals(target.getName(), f.getName());
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void getAllFleets() {
+        try {
+            List<Fleet> fleets = Fleet.getAllFleets(connection);
+            fleets.sort(Comparator.comparingInt(Fleet::getId));
+
+            assertEquals(targets, fleets);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void exists() {
+        try {
+            for (Fleet target : targets) {
+                assertTrue(Fleet.exists(connection, target.getName()));
+            }
+
+            assertFalse(Fleet.exists(connection, "Fleet that does not exist"));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void populateUsers() {
+        try {
             // Bogus user id -- should yield every added user.
             fleet0.populateUsers(connection, 12312345);
             assertEquals(2, fleet0.getUsers().size());
@@ -48,12 +126,50 @@ public class FleetTest {
     }
 
     @Test
-    void testHasAirsync() {
-        try (Connection connection = H2Database.getConnection()) {
+    void getWaitingUserCount() {
+        try {
+            Fleet fleet = targets.get(0);
+            fleet.populateUsers(connection, -1);
+            assertEquals(0, fleet.getWaitingUserCount());
+
+            fleet = targets.get(1);
+            fleet.populateUsers(connection, -1);
+            assertEquals(2, fleet.getWaitingUserCount());
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void hasAirsync() {
+        try {
             assertFalse(fleet0.hasAirsync(connection));
             assertTrue(airsyncFleet.hasAirsync(connection));
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    @AfterAll
+    public static void create() {
+        try (Connection connection = H2Database.getConnection()) {
+            Fleet newFleet = Fleet.create(connection, "Cool Fleet");
+            assertFalse(targets.stream().anyMatch(f -> f.getId() == newFleet.getId()));
+            assertEquals("Cool Fleet", newFleet.getName());
+        } catch (SQLException | AccountException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterAll
+    public static void create2() {
+        for (Fleet fleet : targets) {
+            assertThrows(AccountException.class, () -> {
+                try (Connection connection = H2Database.getConnection()) {
+                    Fleet.create(connection, fleet.getName());
+                }
+            });
         }
     }
 

--- a/ngafid-core/src/test/java/org/ngafid/core/account/FleetTest.java
+++ b/ngafid-core/src/test/java/org/ngafid/core/account/FleetTest.java
@@ -1,0 +1,60 @@
+package org.ngafid.core.account;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.ngafid.core.H2Database;
+import org.ngafid.core.accounts.Fleet;
+import org.ngafid.core.accounts.User;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FleetTest {
+    private Fleet fleet0 = new Fleet(0, "Test Fleet");
+    private Fleet airsyncFleet = new Fleet(1, "Airsync Fleet");
+    private static User user0 = null;
+
+
+    @BeforeAll
+    public static void setup() {
+        try (Connection connection = H2Database.getConnection()) {
+            user0 = User.get(connection, 0, 0);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testConstructor() {
+        assertEquals(0, fleet0.getId());
+        assertEquals("Test Fleet", fleet0.getName());
+    }
+
+    @Test
+    void testPopulateUsers() {
+        try (Connection connection = H2Database.getConnection()) {
+            // Bogus user id -- should yield every added user.
+            fleet0.populateUsers(connection, 12312345);
+            assertEquals(2, fleet0.getUsers().size());
+
+            fleet0.populateUsers(connection, 0);
+            assertEquals(1, fleet0.getUsers().size());
+
+        } catch (SQLException e) {
+            fail("SQLException thrown: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testHasAirsync() {
+        try (Connection connection = H2Database.getConnection()) {
+            assertFalse(fleet0.hasAirsync(connection));
+            assertTrue(airsyncFleet.hasAirsync(connection));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/ngafid-db/src/changelogs/00-accounts/00-fleets.sql
+++ b/ngafid-db/src/changelogs/00-accounts/00-fleets.sql
@@ -8,6 +8,9 @@ CREATE TABLE fleet (
     PRIMARY KEY (id)
 );
 
+--changeset josh:fleet-unique-name labels:accounts
+ALTER TABLE fleet ADD UNIQUE (fleet_name);
+
 --changeset josh:fleet-test labels:accounts
 CREATE TABLE test (
     id INT NOT NULL AUTO_INCREMENT,

--- a/ngafid-db/src/changelogs/01-flights/05-events.sql
+++ b/ngafid-db/src/changelogs/01-flights/05-events.sql
@@ -83,9 +83,9 @@ CREATE TABLE event_metadata_keys (
     PRIMARY KEY(id)
 );
 
---changeset josh:event-metadata-keys-static labels:flights,events
-INSERT INTO event_metadata_keys (name) VALUES ("lateral_distance");
-INSERT INTO event_metadata_keys (name) VALUES ("vertical_distance");
+--changeset josh:event-static-metadata-keys labels:flights,events
+INSERT INTO event_metadata_keys (name) VALUES ('lateral_distance');
+INSERT INTO event_metadata_keys (name) VALUES ('vertical_distance');
 
 --changeset josh:event-metadata labels:flights,events
 CREATE TABLE event_metadata (

--- a/ngafid-db/src/changelogs/01-flights/06-event-definitions.sql
+++ b/ngafid-db/src/changelogs/01-flights/06-event-definitions.sql
@@ -1,77 +1,374 @@
 --liquibase formatted sql
 
 --changeset josh:event-definitions-static labels:messages
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (-7,0,8,'Low Ending Fuel',1,30,'[\"Total Fuel\"]','{\"text\" : \"Average fuel the past 15 seconds was less than 11.0\"}','[\"Total Fuel\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (-6,0,3,'Low Ending Fuel',1,30,'[\"Total Fuel\"]','{\"text\" : \"Average fuel the past 15 seconds was less than 17.56\"}','[\"Total Fuel\"]','MIN','null');
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (-5,0,2,'Low Ending Fuel',1,30,'[\"Total Fuel\"]','{\"text\" : \"Average fuel the past 15 seconds was less than 8.00\"}','[\"Total Fuel\"]','MIN','null');
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (-4,0,1,'Low Ending Fuel',1,30,'[\"Total Fuel\"]','{\"text\" : \"Average fuel the past 15 seconds was less than 8.25\"}','[\"Total Fuel\"]','MIN','null');
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (-3,0,0,'High Altitude Spin',1,30,'[\"NormAc\", \"AltAGL\", \"VSpd\", \"IAS\"]','{\"text\" : \"Spin at or above 4,000\' AGL\"}','[\"NormAc\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (-2,0,0,'Low Altitude Spin',1,30,'[\"NormAc\", \"AltAGL\", \"VSpd\", \"IAS\"]','{\"text\" : \"Spin below 4,000\' AGL\"}','[\"NormAc\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (-1,0,0,'Proximity',1,30,'[\"AltAGL\", \"AltMSL\", \"Latitude\", \"Longitude\", \"Lcl Date\", \"Lcl Time\", \"UTCOfst\"]','{\"text\" : \"Aircraft within 500 ft of another aircraft and above above 50ft AGL\"}','[]','MIN','null');
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (1,0,0,'Low Pitch',1,30,'[\"Pitch\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\"<\",\"-30\"]}]}','[\"Pitch\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (2,0,0,'High Pitch',1,30,'[\"Pitch\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\">\",\"30\"]}]}','[\"Pitch\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (3,0,0,'Low Lateral Acceleration',1,30,'[\"LatAc\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"LatAc\",\"<\",\"-1.33\"]}]}','[\"LatAc\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (4,0,0,'High Lateral Acceleration',1,30,'[\"LatAc\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"LatAc\",\">\",\"1.33\"]}]}','[\"LatAc\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (5,0,0,'Low Vertical Acceleration',1,30,'[\"NormAc\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"NormAc\",\"<\",\"-2.52\"]}]}','[\"NormAc\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (6,0,0,'High Vertical Acceleration',1,30,'[\"NormAc\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"NormAc\",\">\",\"2.8\"]}]}','[\"NormAc\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (7,0,0,'Roll',1,30,'[\"Roll\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Roll\",\"<\",\"-60\"]},{\"type\":\"RULE\",\"inputs\":[\"Roll\",\">\",\"60\"]}]}','[\"Roll\"]','MAX_ABS',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (8,0,0,'VSI on Final',1,30,'[\"VSpd\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"VSpd\",\"<=\",\"-1500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"500\"]}]}','[\"VSpd\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (9,0,2,'Airspeed',1,30,'[\"IAS\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">\",\"163\"]}]}','[\"IAS\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (11,0,1,'Airspeed',1,30,'[\"IAS\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">\",\"154\"]}]}','[\"IAS\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (12,0,3,'Airspeed',1,30,'[\"IAS\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">\",\"202\"]}]}','[\"IAS\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (13,0,4,'Airspeed',1,30,'[\"IAS\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">\",\"200\"]}]}','[\"IAS\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (14,0,2,'Altitude',1,30,'[\"AltMSL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltMSL\",\">\",\"12800\"]}]}','[\"AltMSL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (15,0,4,'Altitude',1,30,'[\"AltMSL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltMSL\",\">\",\"12800\"]}]}','[\"AltMSL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (16,0,1,'Altitude',1,30,'[\"AltMSL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltMSL\",\">\",\"12800\"]}]}','[\"AltMSL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (17,0,3,'Altitude',1,30,'[\"AltMSL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltMSL\",\">\",\"12800\"]}]}','[\"AltMSL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (21,0,2,'Cylinder Head Temperature',1,30,'[\"E1 CHT4\",\"E1 CHT3\",\"E1 CHT2\",\"E1 CHT1\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT2\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT3\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT4\",\">\",\"500\"]}]}','[\"E1 CHT4\",\"E1 CHT3\",\"E1 CHT2\",\"E1 CHT1\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (22,0,4,'Cylinder Head Temperature',1,30,'[\"E1 CHT4\",\"E1 CHT3\",\"E1 CHT6\",\"E1 CHT5\",\"E1 CHT2\",\"E1 CHT1\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT2\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT3\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT4\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT5\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT6\",\">\",\"460\"]}]}','[\"E1 CHT4\",\"E1 CHT3\",\"E1 CHT6\",\"E1 CHT5\",\"E1 CHT2\",\"E1 CHT1\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (23,0,3,'Cylinder Head Temperature',1,30,'[\"E1 CHT1\",\"E2 CHT1\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT1\",\">\",\"500\"]}]}','[\"E1 CHT1\",\"E2 CHT1\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (24,0,2,'Low Oil Pressure',1,30,'[\"E1 OilP\",\"E1 RPM\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]}','[\"E1 OilP\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (25,0,4,'Low Oil Pressure',1,30,'[\"E1 OilP\",\"E1 RPM\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"10\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]}','[\"E1 OilP\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (26,0,1,'Low Oil Pressure',1,30,'[\"E1 OilP\",\"E1 RPM\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]}','[\"E1 OilP\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (27,0,3,'Low Oil Pressure',1,30,'[\"E1 OilP\",\"E2 RPM\",\"E2 OilP\",\"E1 RPM\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]},{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E2 OilP\",\"<\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 RPM\",\">\",\"500\"]}]}]}','[\"E1 OilP\",\"E2 OilP\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (28,0,2,'Low Fuel',1,30,'[\"Pitch\",\"Total Fuel\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Total Fuel\",\"<\",\"8.0\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\"<\",\"5\"]}]}','[\"Total Fuel\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (29,0,1,'Low Fuel',1,30,'[\"Pitch\",\"Total Fuel\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Total Fuel\",\"<\",\"8.25\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\"<\",\"5\"]}]}','[\"Total Fuel\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (30,0,3,'Low Fuel',1,30,'[\"Pitch\",\"Total Fuel\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Total Fuel\",\"<\",\"17.56\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\"<\",\"5\"]}]}','[\"Total Fuel\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (31,0,2,'Low Airspeed on Approach',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"57\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (32,0,1,'Low Airspeed on Approach',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"56\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (33,0,3,'Low Airspeed on Approach',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"66\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (34,0,4,'Low Airspeed on Approach',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"67\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (35,0,2,'Low Airspeed on Climbout',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"52\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (36,0,1,'Low Airspeed on Climbout',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"59\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (37,0,3,'Low Airspeed on Climbout',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"70\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (38,0,4,'Low Airspeed on Climbout',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"60\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (39,0,2,'CHT Sensor Divergence',1,30,'[\"E1 CHT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT Divergence\",\">\",\"100\"]}]}','[\"E1 CHT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (40,0,1,'CHT Sensor Divergence',1,30,'[\"E1 CHT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT Divergence\",\">\",\"100\"]}]}','[\"E1 CHT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (41,0,4,'CHT Sensor Divergence',1,30,'[\"E1 CHT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT Divergence\",\">\",\"100\"]}]}','[\"E1 CHT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (42,0,2,'EGT Sensor Divergence',1,30,'[\"E1 EGT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]}]}','[\"E1 EGT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (43,0,4,'EGT Sensor Divergence',1,30,'[\"E1 EGT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]}]}','[\"E1 EGT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (44,0,1,'EGT Sensor Divergence',1,30,'[\"E1 EGT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]}]}','[\"E1 EGT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (45,0,3,'EGT Sensor Divergence',1,30,'[\"E2 EGT Divergence\",\"E1 EGT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 EGT Divergence\",\">\",\"400\"]}]}','[\"E2 EGT Divergence\",\"E1 EGT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (46,0,2,'Engine Shutdown Below 3000 Ft',1,30,'[\"E1 RPM\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\"<\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"3000\"]}]}','[\"AltAGL\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (47,0,1,'Engine Shutdown Below 3000 Ft',1,30,'[\"E1 RPM\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\"<\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"3000\"]}]}','[\"AltAGL\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (48,0,4,'Engine Shutdown Below 3000 Ft',1,30,'[\"E1 RPM\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\"<\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"3000\"]}]}','[\"AltAGL\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (49,0,3,'Engine Shutdown Below 3000 Ft',1,30,'[\"E2 RPM\",\"E1 RPM\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"3000\"]},{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\"<\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 RPM\",\"<\",\"100\"]}]}]}','[\"AltAGL\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (50,0,2,'High Altitude LOC-I',2,1,'[\"AltAGL\",\"LOC-I Index\",\"Coordination Index\",\"Yaw Rate\",\"AltB\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"LOC-I Index\",\">=\",\"1\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"1500\"]}]}','[\"Yaw Rate\", \"AltAGL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (51,0,0,'High Altitude Stall',2,1,'[\"AltAGL\",\"Stall Index\",\"Coordination Index\",\"AOASimple\",\"AltB\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Stall Index\",\">=\",\"1\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"1500\"]}]}','[\"AOASimple\", \"AltAGL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (52,0,0,'Low Altitude Stall',2,1,'[\"AltAGL\",\"Stall Index\",\"Coordination Index\",\"AOASimple\",\"AltB\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Stall Index\",\">=\",\"1\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"1500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"100\"]}]}','[\"AOASimple\", \"AltAGL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (53,0,2,'Low Altitude LOC-I',2,1,'[\"AltAGL\",\"LOC-I Index\",\"Coordination Index\",\"Yaw Rate\",\"AltB\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"LOC-I Index\",\">=\",\"1\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"1500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"100\"]}]}','[\"Yaw Rate\", \"AltAGL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (55,0,2,'Tail Strike',1,30,'[\"AltAGL\",\"IAS\",\"Pitch\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"5\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\">=\",\"11\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<=\",\"55\"]}]}','[\"Pitch\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (56,0,22,'Low Battery Level',1,30,'[\"Battery(0):battery%\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Battery(0):battery%\",\"<\",\"25\"]}]}','[\"Battery(0):battery%\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (57,0,16,'Battery Not Charging',60,90,'[\"DID_ACPARAM_BATT_CHARGING\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"DID_ACPARAM_BATT_CHARGING\",\"<\",\"1\"]}]}','[\"DID_ACPARAM_BATT_CHARGING\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (58,0,22,'Low Positional Accuracy',1,30,'[\"gpsHealth\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"gpsHealth\",\"<\",\"2\"]}]}','[\"gpsHealth\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (59,0,23,'High Altitude Limit Exceeded',1,30,'[\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"400\"]}]}','[\"AltAGL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (60,0,16,'High Altitude Limit Exceeded',1,30,'[\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"400\"]}]}','[\"AltAGL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (61,0,22,'High Altitude Limit Exceeded',1,30,'[\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"400\"]}]}','[\"AltAGL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (62,0,21,'Cylinder Head Temperature',1,30,'[\"E1 CHT1\",\"E1 CHT2\",\"E1 CHT3\",\"E1 CHT4\",\"E1 CHT5\",\"E1 CHT6\",\"E2 CHT1\",\"E2 CHT2\",\"E2 CHT3\",\"E2 CHT4\",\"E2 CHT5\",\"E2 CHT6\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT2\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT3\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT4\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT5\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT6\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT1\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT2\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT3\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT4\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT5\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT6\",\">\",\"460\"]}]}','[\"E1 CHT1\",\"E1 CHT2\",\"E1 CHT3\",\"E1 CHT4\",\"E1 CHT5\",\"E1 CHT6\",\"E2 CHT1\",\"E2 CHT2\",\"E2 CHT3\",\"E2 CHT4\",\"E2 CHT5\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (63,0,8,'Airspeed',1,30,'[\"IAS\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"178\"]}]}','[\"IAS\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (64,0,8,'Altitude',1,30,'[\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"12500\"]}]}','[\"AltAGL\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (65,0,8,'CHT Divergence',1,30,'[\"E1 CHT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT Divergence\",\">\",\"100\"]}]}','[\"E1 CHT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (66,0,8,'High CHT',1,30,'[\"E1 CHT1\",\"E1 CHT2\",\"E1 CHT3\",\"E1 CHT4\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"435\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT2\",\">\",\"435\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT3\",\">\",\"435\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT4\",\">\",\"435\"]}]}','[\"E1 CHT1\",\"E1 CHT2\",\"E1 CHT3\",\"E1 CHT4\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (67,0,8,'E1 EGT Divergence',1,30,'[\"E1 EGT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]}]}','[\"E1 EGT Divergence\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (68,0,8,'Low Airspeed on Climbout',1,30,'[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"57\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (69,0,8,'Low Airspeed on Approach',1,30,'[\"AltAGL\",\"AltMSL Lag Diff\",\"IAS\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"63\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}','[\"IAS\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (70,0,8,'Low Oil Pressure',1,30,'[\"E1 OilP\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]}','[\"E1 OilP\"]','MIN',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (71,0,8,'Tail Strike',1,30,'[\"AltAGL\",\"IAS\",\"Pitch\"]','{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"5\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\">=\",\"11\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<=\",\"59\"]}]}','[\"Pitch\"]','MAX',NULL);
-INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`, `condition_json`, `severity_column_names`, `severity_type`, `color`) VALUES (72,0,2,'EGT Sensor Divergence (200 degrees)',1,30,'[\"E1 EGT Divergence\"]','{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"200\"]}]}','[\"E1 EGT Divergence\"]','MAX',NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (-7, 0, 8, 'Low Ending Fuel', 1, 30, '[\"Total Fuel\"]',
+        '{\"text\" : \"Average fuel the past 15 seconds was less than 11.0\"}', '[\"Total Fuel\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (-6, 0, 3, 'Low Ending Fuel', 1, 30, '[\"Total Fuel\"]',
+        '{\"text\" : \"Average fuel the past 15 seconds was less than 17.56\"}', '[\"Total Fuel\"]', 'MIN', 'null');
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (-5, 0, 2, 'Low Ending Fuel', 1, 30, '[\"Total Fuel\"]',
+        '{\"text\" : \"Average fuel the past 15 seconds was less than 8.00\"}', '[\"Total Fuel\"]', 'MIN', 'null');
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (-4, 0, 1, 'Low Ending Fuel', 1, 30, '[\"Total Fuel\"]',
+        '{\"text\" : \"Average fuel the past 15 seconds was less than 8.25\"}', '[\"Total Fuel\"]', 'MIN', 'null');
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (-3, 0, 0, 'High Altitude Spin', 1, 30, '[\"NormAc\", \"AltAGL\", \"VSpd\", \"IAS\"]',
+        '{\"text\" : \"Spin at or above 4,000'' AGL\"}', '[\"NormAc\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (-2, 0, 0, 'Low Altitude Spin', 1, 30, '[\"NormAc\", \"AltAGL\", \"VSpd\", \"IAS\"]',
+        '{\"text\" : \"Spin below 4,000'' AGL\"}', '[\"NormAc\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (-1, 0, 0, 'Proximity', 1, 30,
+        '[\"AltAGL\", \"AltMSL\", \"Latitude\", \"Longitude\", \"Lcl Date\", \"Lcl Time\", \"UTCOfst\"]',
+        '{\"text\" : \"Aircraft within 500 ft of another aircraft and above above 50ft AGL\"}', '[]', 'MIN', 'null');
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (1, 0, 0, 'Low Pitch', 1, 30, '[\"Pitch\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\"<\",\"-30\"]}]}',
+        '[\"Pitch\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (2, 0, 0, 'High Pitch', 1, 30, '[\"Pitch\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\">\",\"30\"]}]}',
+        '[\"Pitch\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (3, 0, 0, 'Low Lateral Acceleration', 1, 30, '[\"LatAc\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"LatAc\",\"<\",\"-1.33\"]}]}',
+        '[\"LatAc\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (4, 0, 0, 'High Lateral Acceleration', 1, 30, '[\"LatAc\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"LatAc\",\">\",\"1.33\"]}]}',
+        '[\"LatAc\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (5, 0, 0, 'Low Vertical Acceleration', 1, 30, '[\"NormAc\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"NormAc\",\"<\",\"-2.52\"]}]}',
+        '[\"NormAc\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (6, 0, 0, 'High Vertical Acceleration', 1, 30, '[\"NormAc\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"NormAc\",\">\",\"2.8\"]}]}',
+        '[\"NormAc\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (7, 0, 0, 'Roll', 1, 30, '[\"Roll\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Roll\",\"<\",\"-60\"]},{\"type\":\"RULE\",\"inputs\":[\"Roll\",\">\",\"60\"]}]}',
+        '[\"Roll\"]', 'MAX_ABS', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (8, 0, 0, 'VSI on Final', 1, 30, '[\"VSpd\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"VSpd\",\"<=\",\"-1500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"500\"]}]}',
+        '[\"VSpd\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (9, 0, 2, 'Airspeed', 1, 30, '[\"IAS\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">\",\"163\"]}]}',
+        '[\"IAS\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (11, 0, 1, 'Airspeed', 1, 30, '[\"IAS\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">\",\"154\"]}]}',
+        '[\"IAS\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (12, 0, 3, 'Airspeed', 1, 30, '[\"IAS\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">\",\"202\"]}]}',
+        '[\"IAS\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (13, 0, 4, 'Airspeed', 1, 30, '[\"IAS\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">\",\"200\"]}]}',
+        '[\"IAS\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (14, 0, 2, 'Altitude', 1, 30, '[\"AltMSL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltMSL\",\">\",\"12800\"]}]}',
+        '[\"AltMSL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (15, 0, 4, 'Altitude', 1, 30, '[\"AltMSL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltMSL\",\">\",\"12800\"]}]}',
+        '[\"AltMSL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (16, 0, 1, 'Altitude', 1, 30, '[\"AltMSL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltMSL\",\">\",\"12800\"]}]}',
+        '[\"AltMSL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (17, 0, 3, 'Altitude', 1, 30, '[\"AltMSL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltMSL\",\">\",\"12800\"]}]}',
+        '[\"AltMSL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (21, 0, 2, 'Cylinder Head Temperature', 1, 30, '[\"E1 CHT4\",\"E1 CHT3\",\"E1 CHT2\",\"E1 CHT1\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT2\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT3\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT4\",\">\",\"500\"]}]}',
+        '[\"E1 CHT4\",\"E1 CHT3\",\"E1 CHT2\",\"E1 CHT1\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (22, 0, 4, 'Cylinder Head Temperature', 1, 30,
+        '[\"E1 CHT4\",\"E1 CHT3\",\"E1 CHT6\",\"E1 CHT5\",\"E1 CHT2\",\"E1 CHT1\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT2\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT3\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT4\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT5\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT6\",\">\",\"460\"]}]}',
+        '[\"E1 CHT4\",\"E1 CHT3\",\"E1 CHT6\",\"E1 CHT5\",\"E1 CHT2\",\"E1 CHT1\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (23, 0, 3, 'Cylinder Head Temperature', 1, 30, '[\"E1 CHT1\",\"E2 CHT1\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT1\",\">\",\"500\"]}]}',
+        '[\"E1 CHT1\",\"E2 CHT1\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (24, 0, 2, 'Low Oil Pressure', 1, 30, '[\"E1 OilP\",\"E1 RPM\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]}',
+        '[\"E1 OilP\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (25, 0, 4, 'Low Oil Pressure', 1, 30, '[\"E1 OilP\",\"E1 RPM\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"10\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]}',
+        '[\"E1 OilP\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (26, 0, 1, 'Low Oil Pressure', 1, 30, '[\"E1 OilP\",\"E1 RPM\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]}',
+        '[\"E1 OilP\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (27, 0, 3, 'Low Oil Pressure', 1, 30, '[\"E1 OilP\",\"E2 RPM\",\"E2 OilP\",\"E1 RPM\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]},{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E2 OilP\",\"<\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 RPM\",\">\",\"500\"]}]}]}',
+        '[\"E1 OilP\",\"E2 OilP\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (28, 0, 2, 'Low Fuel', 1, 30, '[\"Pitch\",\"Total Fuel\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Total Fuel\",\"<\",\"8.0\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\"<\",\"5\"]}]}',
+        '[\"Total Fuel\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (29, 0, 1, 'Low Fuel', 1, 30, '[\"Pitch\",\"Total Fuel\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Total Fuel\",\"<\",\"8.25\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\"<\",\"5\"]}]}',
+        '[\"Total Fuel\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (30, 0, 3, 'Low Fuel', 1, 30, '[\"Pitch\",\"Total Fuel\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Total Fuel\",\"<\",\"17.56\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\"<\",\"5\"]}]}',
+        '[\"Total Fuel\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (31, 0, 2, 'Low Airspeed on Approach', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"57\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (32, 0, 1, 'Low Airspeed on Approach', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"56\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (33, 0, 3, 'Low Airspeed on Approach', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"66\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (34, 0, 4, 'Low Airspeed on Approach', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"67\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (35, 0, 2, 'Low Airspeed on Climbout', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"52\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (36, 0, 1, 'Low Airspeed on Climbout', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"59\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (37, 0, 3, 'Low Airspeed on Climbout', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"70\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (38, 0, 4, 'Low Airspeed on Climbout', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"60\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (39, 0, 2, 'CHT Sensor Divergence', 1, 30, '[\"E1 CHT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT Divergence\",\">\",\"100\"]}]}',
+        '[\"E1 CHT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (40, 0, 1, 'CHT Sensor Divergence', 1, 30, '[\"E1 CHT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT Divergence\",\">\",\"100\"]}]}',
+        '[\"E1 CHT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (41, 0, 4, 'CHT Sensor Divergence', 1, 30, '[\"E1 CHT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT Divergence\",\">\",\"100\"]}]}',
+        '[\"E1 CHT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (42, 0, 2, 'EGT Sensor Divergence', 1, 30, '[\"E1 EGT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]}]}',
+        '[\"E1 EGT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (43, 0, 4, 'EGT Sensor Divergence', 1, 30, '[\"E1 EGT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]}]}',
+        '[\"E1 EGT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (44, 0, 1, 'EGT Sensor Divergence', 1, 30, '[\"E1 EGT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]}]}',
+        '[\"E1 EGT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (45, 0, 3, 'EGT Sensor Divergence', 1, 30, '[\"E2 EGT Divergence\",\"E1 EGT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 EGT Divergence\",\">\",\"400\"]}]}',
+        '[\"E2 EGT Divergence\",\"E1 EGT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (46, 0, 2, 'Engine Shutdown Below 3000 Ft', 1, 30, '[\"E1 RPM\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\"<\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"3000\"]}]}',
+        '[\"AltAGL\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (47, 0, 1, 'Engine Shutdown Below 3000 Ft', 1, 30, '[\"E1 RPM\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\"<\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"3000\"]}]}',
+        '[\"AltAGL\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (48, 0, 4, 'Engine Shutdown Below 3000 Ft', 1, 30, '[\"E1 RPM\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\"<\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"3000\"]}]}',
+        '[\"AltAGL\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (49, 0, 3, 'Engine Shutdown Below 3000 Ft', 1, 30, '[\"E2 RPM\",\"E1 RPM\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"3000\"]},{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\"<\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 RPM\",\"<\",\"100\"]}]}]}',
+        '[\"AltAGL\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (50, 0, 2, 'High Altitude LOC-I', 2, 1,
+        '[\"AltAGL\",\"LOC-I Index\",\"Coordination Index\",\"Yaw Rate\",\"AltB\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"LOC-I Index\",\">=\",\"1\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"1500\"]}]}',
+        '[\"Yaw Rate\", \"AltAGL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (51, 0, 0, 'High Altitude Stall', 2, 1,
+        '[\"AltAGL\",\"Stall Index\",\"Coordination Index\",\"AOASimple\",\"AltB\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Stall Index\",\">=\",\"1\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"1500\"]}]}',
+        '[\"AOASimple\", \"AltAGL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (52, 0, 0, 'Low Altitude Stall', 2, 1,
+        '[\"AltAGL\",\"Stall Index\",\"Coordination Index\",\"AOASimple\",\"AltB\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Stall Index\",\">=\",\"1\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"1500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"100\"]}]}',
+        '[\"AOASimple\", \"AltAGL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (53, 0, 2, 'Low Altitude LOC-I', 2, 1,
+        '[\"AltAGL\",\"LOC-I Index\",\"Coordination Index\",\"Yaw Rate\",\"AltB\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"LOC-I Index\",\">=\",\"1\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"1500\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"100\"]}]}',
+        '[\"Yaw Rate\", \"AltAGL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (55, 0, 2, 'Tail Strike', 1, 30, '[\"AltAGL\",\"IAS\",\"Pitch\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"5\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\">=\",\"11\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<=\",\"55\"]}]}',
+        '[\"Pitch\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (56, 0, 22, 'Low Battery Level', 1, 30, '[\"Battery(0):battery%\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"Battery(0):battery%\",\"<\",\"25\"]}]}',
+        '[\"Battery(0):battery%\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (57, 0, 16, 'Battery Not Charging', 60, 90, '[\"DID_ACPARAM_BATT_CHARGING\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"DID_ACPARAM_BATT_CHARGING\",\"<\",\"1\"]}]}',
+        '[\"DID_ACPARAM_BATT_CHARGING\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (58, 0, 22, 'Low Positional Accuracy', 1, 30, '[\"gpsHealth\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"gpsHealth\",\"<\",\"2\"]}]}',
+        '[\"gpsHealth\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (59, 0, 23, 'High Altitude Limit Exceeded', 1, 30, '[\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"400\"]}]}',
+        '[\"AltAGL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (60, 0, 16, 'High Altitude Limit Exceeded', 1, 30, '[\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"400\"]}]}',
+        '[\"AltAGL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (61, 0, 22, 'High Altitude Limit Exceeded', 1, 30, '[\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"400\"]}]}',
+        '[\"AltAGL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (62, 0, 21, 'Cylinder Head Temperature', 1, 30,
+        '[\"E1 CHT1\",\"E1 CHT2\",\"E1 CHT3\",\"E1 CHT4\",\"E1 CHT5\",\"E1 CHT6\",\"E2 CHT1\",\"E2 CHT2\",\"E2 CHT3\",\"E2 CHT4\",\"E2 CHT5\",\"E2 CHT6\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT2\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT3\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT4\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT5\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT6\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT1\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT2\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT3\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT4\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT5\",\">\",\"460\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT6\",\">\",\"460\"]}]}',
+        '[\"E1 CHT1\",\"E1 CHT2\",\"E1 CHT3\",\"E1 CHT4\",\"E1 CHT5\",\"E1 CHT6\",\"E2 CHT1\",\"E2 CHT2\",\"E2 CHT3\",\"E2 CHT4\",\"E2 CHT5\"]',
+        'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (63, 0, 8, 'Airspeed', 1, 30, '[\"IAS\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"178\"]}]}',
+        '[\"IAS\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (64, 0, 8, 'Altitude', 1, 30, '[\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">=\",\"12500\"]}]}',
+        '[\"AltAGL\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (65, 0, 8, 'CHT Divergence', 1, 30, '[\"E1 CHT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT Divergence\",\">\",\"100\"]}]}',
+        '[\"E1 CHT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (66, 0, 8, 'High CHT', 1, 30, '[\"E1 CHT1\",\"E1 CHT2\",\"E1 CHT3\",\"E1 CHT4\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 CHT1\",\">\",\"435\"]},{\"type\":\"RULE\",\"inputs\":[\"E2 CHT2\",\">\",\"435\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT3\",\">\",\"435\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 CHT4\",\">\",\"435\"]}]}',
+        '[\"E1 CHT1\",\"E1 CHT2\",\"E1 CHT3\",\"E1 CHT4\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (67, 0, 8, 'E1 EGT Divergence', 1, 30, '[\"E1 EGT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"400\"]}]}',
+        '[\"E1 EGT Divergence\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (68, 0, 8, 'Low Airspeed on Climbout', 1, 30, '[\"AltMSL Lag Diff\",\"IAS\",\"AltAGL\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"20\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"57\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\">\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (69, 0, 8, 'Low Airspeed on Approach', 1, 30, '[\"AltAGL\",\"AltMSL Lag Diff\",\"IAS\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<\",\"63\"]},{\"type\":\"RULE\",\"inputs\":[\"AltMSL Lag Diff\",\"<\",\"0\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\">\",\"100\"]},{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<\",\"500\"]}]}',
+        '[\"IAS\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (70, 0, 8, 'Low Oil Pressure', 1, 30, '[\"E1 OilP\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 OilP\",\"<\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"E1 RPM\",\">\",\"500\"]}]}',
+        '[\"E1 OilP\"]', 'MIN', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (71, 0, 8, 'Tail Strike', 1, 30, '[\"AltAGL\",\"IAS\",\"Pitch\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"AND\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"AltAGL\",\"<=\",\"5\"]},{\"type\":\"RULE\",\"inputs\":[\"Pitch\",\">=\",\"11\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\">=\",\"25\"]},{\"type\":\"RULE\",\"inputs\":[\"IAS\",\"<=\",\"59\"]}]}',
+        '[\"Pitch\"]', 'MAX', NULL);
+INSERT INTO `event_definitions` (`id`, `fleet_id`, `airframe_id`, `name`, `start_buffer`, `stop_buffer`, `column_names`,
+                                 `condition_json`, `severity_column_names`, `severity_type`, `color`)
+VALUES (72, 0, 2, 'EGT Sensor Divergence (200 degrees)', 1, 30, '[\"E1 EGT Divergence\"]',
+        '{\"type\":\"GROUP\",\"condition\":\"OR\",\"filters\":[{\"type\":\"RULE\",\"inputs\":[\"E1 EGT Divergence\",\">\",\"200\"]}]}',
+        '[\"E1 EGT Divergence\"]', 'MAX', NULL);

--- a/ngafid-db/src/changelogs/02-views/00-event-statistics.sql
+++ b/ngafid-db/src/changelogs/02-views/00-event-statistics.sql
@@ -148,7 +148,7 @@ FROM
     ON
         flights.id = e.flight_id
 WHERE
-    DATE_SUB(UTC_DATE(), INTERVAL 30 DAY) <= e.end_time
+    (CURRENT_DATE - INTERVAL '30' DAY) <= e.end_time
 GROUP BY
     fleet_id,
     event_definition_id,

--- a/ngafid-db/src/changelogs/02-views/01-flight-statistics.sql
+++ b/ngafid-db/src/changelogs/02-views/01-flight-statistics.sql
@@ -118,7 +118,7 @@ SELECT
 FROM
     flights
 WHERE
-    DATE_SUB(UTC_DATE(), INTERVAL 30 DAY) <= end_time
+    (CURRENT_DATE - INTERVAL '30' DAY) <= end_time
 GROUP BY
     fleet_id,
     airframe_id;
@@ -266,7 +266,7 @@ SELECT
 FROM
     flights
 WHERE
-    DATE_SUB(UTC_DATE(), INTERVAL 30 DAY) <= end_time
+    (CURRENT_DATE - INTERVAL '30' DAY) <= end_time
 GROUP BY
     fleet_id,
     airframe_id;

--- a/ngafid-db/src/test-changelog-root.xml
+++ b/ngafid-db/src/test-changelog-root.xml
@@ -5,10 +5,11 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <!-- 
+    <!--
         These sql scripts will be executed top to bottom in the order they are listed here.
     -->
 
-    <includeAll path="changelogs" relativeToChangelogFile="true"/>
+    <includeAll path="changelogs" relativeToChangelogFile="true" contextFilter="schema"/>
+    <includeAll path="test-data-changelogs" relativeToChangelogFile="true" contextFilter="test-data"/>
 
 </databaseChangeLog>

--- a/ngafid-db/src/test-data-changelogs/00-fleet-and-user.sql
+++ b/ngafid-db/src/test-data-changelogs/00-fleet-and-user.sql
@@ -16,7 +16,9 @@ VALUES (0, 'test@email.com', 'aaaaaaaaaaaaaaaaaaaa', 'John', 'Doe', '123 House R
 --changeset josh:make-dummy-fleet-access labels:accounts,fleet
 INSERT INTO fleet_access
 VALUES (0, 0, 'VIEW'),
-       (1, 0, 'MANAGER');
+       (1, 0, 'MANAGER'),
+       (0, 1, 'WAITING'),
+       (1, 1, 'WAITING');
 
 --changeset josh:make-dummy-airsync-info labels:accounts,fleet
 INSERT INTO airsync_fleet_info

--- a/ngafid-db/src/test-data-changelogs/00-fleet-and-user.sql
+++ b/ngafid-db/src/test-data-changelogs/00-fleet-and-user.sql
@@ -1,0 +1,23 @@
+--liquibase formatted sql
+
+--changeset josh:make-dummy-fleet labels:accounts,fleet
+INSERT INTO fleet
+VALUES (0, 'Test Fleet with ID 0'),
+       (1, 'Test Fleet with ID 1');
+
+--changeset josh:make-dummy-users labels:accounts,users
+INSERT INTO user
+VALUES (0, 'test@email.com', 'aaaaaaaaaaaaaaaaaaaa', 'John', 'Doe', '123 House Road', 'CityName', 'CountryName',
+        'StateName', '10001', '', '', CURRENT_DATE, 0, 0, CURRENT_DATE),
+       (1, 'test1@email.com', 'aaaaaaaaaaaaaaaaaaaa', 'John Admin', 'Aggregate Doe', '123 House Road', 'CityName',
+        'CountryName', 'StateName', '10001', '', '', CURRENT_DATE, 1, 1, CURRENT_DATE);
+
+
+--changeset josh:make-dummy-fleet-access labels:accounts,fleet
+INSERT INTO fleet_access
+VALUES (0, 0, 'VIEW'),
+       (1, 0, 'MANAGER');
+
+--changeset josh:make-dummy-airsync-info labels:accounts,fleet
+INSERT INTO airsync_fleet_info
+VALUES (1, 'Airsync Name', 'API_KEY', 'API_SECRET', current_date, NULL, NULL);

--- a/ngafid-static/templates/aggregate.html
+++ b/ngafid-static/templates/aggregate.html
@@ -14,41 +14,11 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    imports_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    fleet_info_js
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{imports_js}}}
+            {{{fleet_info_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/airsync_imports.html
+++ b/ngafid-static/templates/airsync_imports.html
@@ -14,34 +14,10 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    imports_js
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{imports_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/airsync_uploads.html
+++ b/ngafid-static/templates/airsync_uploads.html
@@ -14,41 +14,11 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    uploads_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    lastUpdateTime_js
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{uploads_js}}}
+            {{{lastUpdateTime_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/create_account.html
+++ b/ngafid-static/templates/create_account.html
@@ -15,13 +15,7 @@
     <link rel='stylesheet' href='/css/font-awesome.min.css'>
 
     <script>
-        {
-            {
-                {
-                    fleetnames_js
-                }
-            }
-        }
+            {{{fleetnames_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/create_event.html
+++ b/ngafid-static/templates/create_event.html
@@ -19,20 +19,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    create_event_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{create_event_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/event_definitions_display.html
+++ b/ngafid-static/templates/event_definitions_display.html
@@ -16,20 +16,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    events_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{events_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/event_statistics.html
+++ b/ngafid-static/templates/event_statistics.html
@@ -16,20 +16,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    events_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{events_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/flight.html
+++ b/ngafid-static/templates/flight.html
@@ -19,20 +19,8 @@
 
     <script>
         var plotMapHidden = false;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    flight_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{flight_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/flight_display.html
+++ b/ngafid-static/templates/flight_display.html
@@ -16,20 +16,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    events_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{events_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/flights.html
+++ b/ngafid-static/templates/flights.html
@@ -19,20 +19,8 @@
     <link rel="stylesheet" href="../js/cesium/Widgets/widgets.css"/>
     <script>
         var plotMapHidden = false;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    flights_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{flights_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/forgot_password.html
+++ b/ngafid-static/templates/forgot_password.html
@@ -15,13 +15,7 @@
     <link rel='stylesheet' href='/css/font-awesome.min.css'>
 
     <script>
-        {
-            {
-                {
-                    fleetnames_js
-                }
-            }
-        }
+            {{{fleetnames_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/imports.html
+++ b/ngafid-static/templates/imports.html
@@ -16,34 +16,10 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    imports_js
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{imports_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/manage_events.html
+++ b/ngafid-static/templates/manage_events.html
@@ -16,20 +16,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    event_manager_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{event_manager_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/manage_fleet.html
+++ b/ngafid-static/templates/manage_fleet.html
@@ -16,20 +16,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    user_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{user_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/ngafid_cesium_new.html
+++ b/ngafid-static/templates/ngafid_cesium_new.html
@@ -13,27 +13,9 @@
     <link rel="stylesheet" href="/Widgets/widgets.css"/>
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    events_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    cesium_data_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{events_js}}}
+            {{{cesium_data_js}}}
     </script>
 
     <style>

--- a/ngafid-static/templates/preferences_page.html
+++ b/ngafid-static/templates/preferences_page.html
@@ -16,62 +16,14 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    imports_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    user_prefs_json
-                }
-            }
-        }
-        {
-            {
-                {
-                    user_name
-                }
-            }
-        }
-        {
-            {
-                {
-                    is_admin
-                }
-            }
-        }
-        {
-            {
-                {
-                    airsync
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{imports_js}}}
+            {{{user_prefs_json}}}
+            {{{user_name}}}
+            {{{is_admin}}}
+            {{{airsync}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/severities.html
+++ b/ngafid-static/templates/severities.html
@@ -16,41 +16,11 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    imports_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    fleet_info_js
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{imports_js}}}
+            {{{fleet_info_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/system_ids.html
+++ b/ngafid-static/templates/system_ids.html
@@ -16,41 +16,11 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    imports_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    system_ids_js
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{imports_js}}}
+            {{{system_ids_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/trends.html
+++ b/ngafid-static/templates/trends.html
@@ -16,41 +16,11 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    imports_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    fleet_info_js
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{imports_js}}}
+            {{{fleet_info_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/turn_to_final.html
+++ b/ngafid-static/templates/turn_to_final.html
@@ -65,20 +65,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    events_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{events_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/update_event.html
+++ b/ngafid-static/templates/update_event.html
@@ -19,20 +19,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    update_event_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{update_event_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/update_password.html
+++ b/ngafid-static/templates/update_password.html
@@ -16,20 +16,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    user_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{user_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/update_profile.html
+++ b/ngafid-static/templates/update_profile.html
@@ -16,20 +16,8 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    user_js
-                }
-            }
-        }
+            {{{navbar_js}}}
+            {{{user_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/uploads.html
+++ b/ngafid-static/templates/uploads.html
@@ -16,41 +16,11 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    user_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    uploads_js
-                }
-            }
-        }
+            {{{user_js}}}
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{uploads_js}}}
     </script>
 
 </head>

--- a/ngafid-static/templates/welcome.html
+++ b/ngafid-static/templates/welcome.html
@@ -15,41 +15,11 @@
 
     <script>
         var plotMapHidden = true;
-        {
-            {
-                {
-                    numPages_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    index_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    navbar_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    imports_js
-                }
-            }
-        }
-        {
-            {
-                {
-                    fleet_info_js
-                }
-            }
-        }
+            {{{numPages_js}}}
+            {{{index_js}}}
+            {{{navbar_js}}}
+            {{{imports_js}}}
+            {{{fleet_info_js}}}
     </script>
 
 </head>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,18 @@
             <version>3.17.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>4.31.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.3.232</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <modules>


### PR DESCRIPTION
Provides access to an in-memory H2 database that can be used to test code that uses database queries. Dummy data can be inserted as well (see the test changesets).

This works by leveraging liquibase's Java API to construct the in memory H2 database with an identical schema to the actual database. A connection can then be obtained from the `H2Database` class.

This should be particularly useful for writing unit tests in the `ngafid-core` module where a lot of the code is just object-relational mapping. 