### PR TITLE
Generic event definition tables + spacing for event definition name groups

### DIFF
--- a/ngafid-frontend/src/event_definitions_display.js
+++ b/ngafid-frontend/src/event_definitions_display.js
@@ -6,23 +6,67 @@ import SignedInNavbar from "./signed_in_navbar";
 import GetAllDescriptions from "./get_all_descriptions";
 
 class EventDefinitionsDisplayPage extends React.Component {
+
     constructor(props) {
+
         super(props);
         this.events = new Map(Object.entries(GetAllDescriptions()));
+
+        console.log("Event Definitions: ", this.events);
+
     }
 
     render() {
-        let rows = [];
 
+        const GENERIC_AIRFRAME_TYPE_INDICATOR = "Unknown";
+
+        const ROW_INDEX_EVENT_NAME = 0;
+        const ROW_INDEX_AIRFRAME = 1;
+        const ROW_INDEX_EVENT_DEFINITION = 2;
+
+        const rowsGeneric = [];
+        const rowsSpecific = [];
+
+        //Add all events to the rows array
         for (let eventName of this.events.keys()) {
+
             for (let airframe of Object.keys(this.events.get(eventName))) {
-                rows.push([eventName, airframe, this.events.get(eventName)[airframe]]);
+
+                //Got a generic event, add it to the generic rows
+                if (airframe === GENERIC_AIRFRAME_TYPE_INDICATOR)
+                    rowsGeneric.push([eventName, airframe, this.events.get(eventName)[airframe]]);
+
+                //Otherwise, add it to the specific rows
+                else 
+                    rowsSpecific.push([eventName, airframe, this.events.get(eventName)[airframe]]);
+
             }
+
+        }
+
+        const PREVIOUS_EVENT_NAME_DEFAULT = "";
+        let previousEventName = PREVIOUS_EVENT_NAME_DEFAULT;
+        const PADDING_AMT_UPDATED = "32px";
+        const PADDING_AMT_NONE = "0px";
+        let eventPadding = PADDING_AMT_NONE;
+        const eventNameUpdated = (eventName) => {
+
+            //Got new event name, apply padding
+            if (eventName !== previousEventName) {
+                eventPadding = PADDING_AMT_UPDATED;
+                previousEventName = eventName;
+                return;
+            }
+
+            //Otherwise, clear padding
+            eventPadding = PADDING_AMT_NONE;
+
         }
 
         return (
             <div style={{overflowX:"hidden", display:"flex", flexDirection:"column", height:"100vh"}}>
 
+                {/* Navbar */}
                 <div style={{flex:"0 0 auto"}}>
                     <SignedInNavbar activePage="event definitions" waitingUserCount={waitingUserCount}
                                     fleetManager={fleetManager} unconfirmedTailsCount={unconfirmedTailsCount}
@@ -30,11 +74,72 @@ class EventDefinitionsDisplayPage extends React.Component {
                     />
                 </div>
 
+                {/* Main Content */}
                 <div style={{overflowY:"auto", flex:"1 1 auto"}}>
-                    <div className="card-body" style={{margin:10, padding:10, borderRadius:5}}>
+                    <div className="card-body" style={{margin:24, padding:12, borderRadius:5}}>
                         <div className="row">
                             <div className="col-md-12">
                                 <Col>
+
+                                    {/* Generic Entries */}
+                                    <h1 className="ml-1 mb-3 mt-1">
+                                        Generic Event Definitions
+                                    </h1>
+                                    <Table striped bordered hover size="sm" className="rounded-0">
+                                        <thead style={{color: "var(--c_text)", backgroundColor: "var(--c_bg)"}}>
+                                            <tr>
+                                                <th>Event Name</th>
+                                                {/* <th style={{minWidth: "10%"}}>Aircraft Type</th> */}
+                                                <th>Event Definition</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody style={{color: "var(--c_text_alt)"}}>
+                                            {rowsGeneric.map((row, index) => (
+                                                <tr
+                                                    key={index}
+                                                    style={{
+                                                        backgroundColor:
+                                                            index % 2 ? "var(--c_row_bg_solid)" : "var(--c_row_bg_alt_solid)",
+                                                    }}
+                                                >
+
+                                                    {/* Event Definition Name */}
+                                                    <th>
+                                                        {row[ROW_INDEX_EVENT_NAME]}
+                                                    </th>
+
+                                                    {/*
+                                                    Event Definition Aircraft Type
+                                                    (Not displayed for generic events)
+
+                                                    <th>
+                                                        {row[ROW_INDEX_AIRFRAME]}
+                                                    </th>
+                                                    */}
+
+                                                    {/* Event Definition Text */}
+                                                    <th
+                                                        style={{
+                                                            fontStyle: "normal",
+                                                            fontWeight: "normal",
+                                                            color: "var(--c_text_alt)",
+                                                        }}
+                                                    >
+                                                        {row[ROW_INDEX_EVENT_DEFINITION]}
+                                                    </th>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </Table>
+
+                                    <div style={{marginTop: "2rem", marginBottom: "1rem"}}>
+                                        <hr style={{backgroundColor: "var(--c_text)"}}/>
+                                    </div>
+
+                                    {/* Specific Entries */}
+                                    <h1 className="ml-1 mb-3 mt-1">
+                                        Specific Event Definitions
+                                    </h1>
                                     <Table striped bordered hover size="sm">
                                         <thead style={{color: "var(--c_text)", backgroundColor: "var(--c_bg)"}}>
                                             <tr>
@@ -44,24 +149,40 @@ class EventDefinitionsDisplayPage extends React.Component {
                                             </tr>
                                         </thead>
                                         <tbody style={{color: "var(--c_text_alt)"}}>
-                                            {rows.map((row, index) => (
+                                            {rowsSpecific.map((row, index) => (
                                                 <tr
                                                     key={index}
                                                     style={{
-                                                        backgroundColor:
-                                                            index % 2 ? "var(--c_row_bg_solid)" : "var(--c_row_bg_alt_solid)",
+                                                        backgroundColor: index % 2 ? "var(--c_row_bg_solid)" : "var(--c_row_bg_alt_solid)",
+                                                        
                                                     }}
                                                 >
-                                                    <th>{row[0]}</th>
-                                                    <th>{row[1]}</th>
+                                                    {eventNameUpdated(row[ROW_INDEX_EVENT_NAME])}
+
+                                                    {/* Event Definition Name */}
+                                                    <th style={{
+                                                        paddingTop: eventPadding,
+                                                    }}>
+                                                        {row[ROW_INDEX_EVENT_NAME]}
+                                                    </th>
+
+                                                    {/* Event Definition Aircraft Type */}
+                                                    <th style={{
+                                                        paddingTop: eventPadding,
+                                                    }}>
+                                                        {row[ROW_INDEX_AIRFRAME]}
+                                                    </th>
+
+                                                    {/* Event Definition Text */}
                                                     <th
                                                         style={{
                                                             fontStyle: "normal",
                                                             fontWeight: "normal",
                                                             color: "var(--c_text_alt)",
+                                                            paddingTop: eventPadding,
                                                         }}
                                                     >
-                                                        {row[2]}
+                                                        {row[ROW_INDEX_EVENT_DEFINITION]}
                                                     </th>
                                                 </tr>
                                             ))}
@@ -79,6 +200,6 @@ class EventDefinitionsDisplayPage extends React.Component {
 }
 
 
-var eventDefinitionsDisplayPage = ReactDOM.render(
+const eventDefinitionsDisplayPage = ReactDOM.render(
     <EventDefinitionsDisplayPage/>, document.querySelector('#event-definitions-display-page')
 )

--- a/ngafid-www/src/main/java/org/ngafid/www/routes/EventJavalinRoutes.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/routes/EventJavalinRoutes.java
@@ -98,7 +98,9 @@ public class EventJavalinRoutes {
     }
 
     private static void getAllEventDescriptions(Context ctx) {
-        final String query = "SELECT event_definitions.id, fleet_id, name, start_buffer, stop_buffer, airframe_id, condition_json, column_names, severity_column_names, severity_type, airframe " + "FROM event_definitions INNER JOIN airframes ON event_definitions.airframe_id=airframes.id";
+
+        final int AIRFRAME_ID_GENERIC = 0;
+        final String query = "SELECT event_definitions.id, fleet_id, name, start_buffer, stop_buffer, airframe_id, condition_json, column_names, severity_column_names, severity_type, airframe " + "FROM event_definitions INNER JOIN airframes ON event_definitions.airframe_id=airframes.id OR event_definitions.airframe_id="+AIRFRAME_ID_GENERIC;
 
         try (Connection connection = Database.getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(query)) {
             LOG.info("preparedStatement: " + preparedStatement);


### PR DESCRIPTION
- getAllEventDescriptions will now also retrieve all event definitions with an airframe ID of 0
- Two tables are used on the Event Definitions page for generic & airframe-specific events
- Spacing is now applied to group different event names in the specific event defs table

![image](https://github.com/user-attachments/assets/c934f7cc-8bd4-4c75-8f1e-21144a474d10)
