### PR TITLE
Email Prefs & Manage Fleet fixes

### DIFF
--- a/ngafid-core/src/main/java/org/ngafid/core/accounts/User.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/accounts/User.java
@@ -470,27 +470,37 @@ public final class User implements Serializable {
      * @param emailPreferences the {@link UserEmailPreferences} instance to store
      * @return an instance of {@link UserEmailPreferences} with all the user's email
      */
-    public static UserEmailPreferences updateUserEmailPreferences(Connection connection, int userId,
-                                                                  Map<String, Boolean> emailPreferences) throws SQLException {
-        String queryString = "INSERT INTO email_preferences (user_id, email_type, enabled) VALUES (?, ?, ?)"
-                + " ON DUPLICATE KEY UPDATE email_type = VALUES(email_type), enabled = VALUES(enabled)";
+    public static UserEmailPreferences updateUserEmailPreferences(Connection connection, int userId, Map<String, Boolean> emailPreferences) throws SQLException {
+
+        final String queryString =
+            "INSERT INTO email_preferences (user_id, email_type, enabled) VALUES (?, ?, ?)"
+            + " ON DUPLICATE KEY UPDATE email_type = VALUES(email_type), enabled = VALUES(enabled)"
+        ;
 
         try (PreparedStatement query = connection.prepareStatement(queryString)) {
-            for (String emailType : emailPreferences.keySet()) {
+
+            for (Map.Entry<String, Boolean> entry : emailPreferences.entrySet()) {
+
                 query.setInt(1, userId);
-                query.setString(2, emailType);
-                query.setBoolean(3, emailPreferences.get(emailType));
+                query.setString(2, entry.getKey());
+                query.setBoolean(3, entry.getValue());
 
                 query.executeUpdate();
-            }
 
+            }
+                
             UserEmailPreferences updatedEmailPreferences = User.getUserEmailPreferences(connection, userId);
 
             User userTarget = UserEmailPreferences.getUser(userId);
-            userTarget.setEmailPreferences(updatedEmailPreferences);
+
+            //Found user in the map, update the email preferences
+            if (userTarget != null)
+                userTarget.setEmailPreferences(updatedEmailPreferences);
 
             return updatedEmailPreferences;
+
         }
+
     }
 
     public void setEmailPreferences(UserEmailPreferences updatedEmailPreferences) {

--- a/ngafid-frontend/src/email_settings.js
+++ b/ngafid-frontend/src/email_settings.js
@@ -146,7 +146,7 @@ class EmailSettingsTableUser extends React.Component {
 
     render() {
         return (
-            <div className="flex flex-row w-full gap-2 items-center justify-center">
+            <div className="flex flex-row w-full gap-4 items-center justify-center">
             {
                 this.state.emailTypes.map((type, index) => (
 
@@ -167,6 +167,10 @@ class EmailSettingsTableUser extends React.Component {
                             //Non-Admin Type
                             :
                             <div className="mr-3 ml-2">
+                                <div className="flex flex-row gap-2 font-bold items-center">
+                                    <i className="fa fa-user"/>
+                                    User
+                                </div>
                                 {type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
                             </div>
                         }

--- a/ngafid-frontend/src/email_settings.js
+++ b/ngafid-frontend/src/email_settings.js
@@ -6,6 +6,10 @@ import $ from 'jquery';
 window.jQuery = $;
 window.$ = $;
 
+
+import './index.css'          //<-- include Tailwind
+
+
 export { EmailSettingsTableUser, EmailSettingsTableManager }
 
 /*
@@ -17,6 +21,7 @@ export { EmailSettingsTableUser, EmailSettingsTableManager }
 class EmailSettingsTableUser extends React.Component {
 
     constructor(props) {
+
         super(props);
         console.log("Generating User Email Settings Table...");
         this.state = {
@@ -24,6 +29,7 @@ class EmailSettingsTableUser extends React.Component {
             settings: {},
             disableFetching : false
         };
+
     }
 
     componentDidMount() {
@@ -62,21 +68,22 @@ class EmailSettingsTableUser extends React.Component {
     //Fetch user email preferences
     getUserEmailPreferences = () => {
 
-        let submissionData = {
-            handleFetchType : "HANDLE_FETCH_USER"
+        const HANDLE_FETCH_TYPE_TARGET = "HANDLE_FETCH_USER";
+        const submissionData = {
+            handleFetchType : HANDLE_FETCH_TYPE_TARGET,
         };
+
+        const urlTarget = `/protected/email_preferences/${HANDLE_FETCH_TYPE_TARGET}`;
 
         $.ajax({
             type: 'GET',
-            url: '/protected/email_preferences',
+            url: urlTarget,
             data: submissionData,
             dataType: 'json',
             async: true,
-
             success: (response) => {
 
-                console.log("got user pref response");
-                console.log(response);
+                console.log("Got user pref response: ", response);
 
                 let emailTypesIn = response.emailTypesKeys;
                 let emailTypesUserIn = response.emailTypesUser;
@@ -90,6 +97,7 @@ class EmailSettingsTableUser extends React.Component {
                 );
 
                 if (this.props.isAdmin) {
+
                     let emailTypesAdmin = emailTypesIn.filter(
                         type => (type.includes("ADMIN") === true)
                     );
@@ -97,10 +105,13 @@ class EmailSettingsTableUser extends React.Component {
                         type => (type.includes("ADMIN") !== true)
                     );
                     emailTypesIn = emailTypesIn.concat(emailTypesAdmin);
+
                 } else {
+
                     emailTypesIn = emailTypesIn.filter(
                         type => (type.includes("ADMIN") !== true)
                     );
+
                 }
 
                 this.setState({
@@ -116,6 +127,7 @@ class EmailSettingsTableUser extends React.Component {
     }
 
     handleCheckboxChange = (type) => {
+
         this.setState(
             prevState => {
                 let prevStateSettings = (prevState.settings || []);
@@ -129,44 +141,47 @@ class EmailSettingsTableUser extends React.Component {
                 this.updateUserEmailPreferences(this.state.settings);
             }
         );
+
     };
 
     render() {
         return (
-            <table style={{
-                width: "100%",
-                textAlign: "center",
-                borderCollapse: "separate",
-                borderSpacing: "16px 16px"
-            }}>
-                <thead>
-                <tr>
-                    {
-                        this.state.emailTypes.map((type, index) => (
-                            <th key={index} style={{textAlign: "center"}}>
+            <div className="flex flex-row w-full gap-2 items-center justify-center">
+            {
+                this.state.emailTypes.map((type, index) => (
+
+                    <div key={index} className="flex flex-row bg-[var(--c_tag_badge)] rounded-lg items-center p-2 pr-4">
+
+                        {
+                            //Admin Type
+                            (type.includes("ADMIN") === true)
+                            ?
+                            <div className="mr-3 ml-2">
+                                <div className="flex flex-row gap-2 font-bold items-center">
+                                    <i className="fa fa-shield"/>
+                                    Admin
+                                </div>
+                                {type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()).replace("ADMIN", "")}
+                            </div>
+
+                            //Non-Admin Type
+                            :
+                            <div className="mr-3 ml-2">
                                 {type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
-                            </th>
-                        ))
-                    }
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    {
-                        this.state.emailTypes.map((type, typeIndex) => (
-                            <td key={typeIndex} style={{ textAlign: "center" }}>
-                                <input
-                                    type="checkbox"
-                                    checked={(this.state.settings && this.state.settings[type]) ? this.state.settings[type] : false}
-                                    onChange={this.state.disableFetching ? () => undefined : () => this.handleCheckboxChange(type)}
-                                    style={{ scale: "2.00" }}
-                                />
-                            </td>
-                        ))
-                    }
-                </tr>
-                </tbody>
-            </table>
+                            </div>
+                        }
+
+                        <input
+                            type="checkbox"
+                            checked={(this.state.settings && this.state.settings[type]) ? this.state.settings[type] : false}
+                            onChange={this.state.disableFetching ? () => undefined : () => this.handleCheckboxChange(type)}
+                            className="ml-2 !scale-200"
+                        />
+                    </div>
+
+                ))
+            }
+            </div>
         )
     }
 };
@@ -180,23 +195,28 @@ class EmailSettingsTableUser extends React.Component {
 class EmailSettingsTableManager extends React.Component {
 
     constructor(props) {
+
         super(props);
         console.log("Generating Manager Email Settings Table...");
         this.state = {
             emailTypes : [],
-            fleetUsers : props.fleetUsers,
+            prefsByUser : {},
             disableFetching : false
         };
+
     }
 
     componentDidMount() {
+
         this.getUserEmailPreferences();
+
     }
 
     updateUserEmailPreferences = (fleetUser, updatedSettings) => {
-        let updatedEmailTypeSettingsTarget = updatedSettings.find(setting => setting.id === fleetUser.id).emailTypesUser;
+        
+        const updatedEmailTypeSettingsTarget = updatedSettings[fleetUser.id].emailTypesUser;
 
-        var submissionData = {
+        const submissionData = {
             handleUpdateType : "HANDLE_UPDATE_MANAGER",
             fleetUserID : fleetUser.id,
             fleetID : fleetUser.fleet.id,
@@ -211,147 +231,333 @@ class EmailSettingsTableManager extends React.Component {
             data: submissionData,
             dataType: 'json',
             async: true,
-            success: () => this.setState({ disableFetching: false }),
-            error: (_, __, errorThrown) => {
+            success: (response) => {
+                
+                this.setState({ disableFetching: false })
+
+            },
+            error: (jqXHR, textStatus, errorThrown) => {
+
                 console.log('Error updating preferences:', errorThrown);
                 this.setState({ disableFetching: false });
+
             }
         });
+
     }
 
     getUserEmailPreferences = () => {
-        let fleetUsers = this.state.fleetUsers;
+
+        const fleetUsers = this.props.fleetUsers;
 
         fleetUsers.forEach(userTarget => {
-            let submissionData = {
-                handleFetchType : "HANDLE_FETCH_MANAGER",
+
+            const HANDLE_FETCH_TYPE_TARGET = "HANDLE_FETCH_MANAGER";
+            const submissionData = {
+                handleFetchType : HANDLE_FETCH_TYPE_TARGET,
                 fleetUserID : userTarget.id,
                 fleetID: userTarget.fleet.id
             };
+            
+            const urlTarget = `/protected/email_preferences/${HANDLE_FETCH_TYPE_TARGET}/${userTarget.id}/${userTarget.fleet.id}`;
 
             $.ajax({
                 type: 'GET',
-                url: '/protected/email_preferences',
+                url: urlTarget,
                 data: submissionData,
                 dataType : 'json',
                 async: true,
                 success : (response) => {
-                    let emailTypesUserIn = response.emailTypesUser;
-                    let emailTypesKeysIn = response.emailTypesKeys.filter(type =>
-                        !type.includes("HIDDEN") && !type.includes("FORCED") && !type.includes("ADMIN")
-                    );
 
-                    this.setState(prevState => {
-                        const fleetUsers = prevState.fleetUsers.map(userCurrent => {
-                            if (userCurrent.id === userTarget.id) {
-                                return {
-                                    ...userCurrent,
-                                    emailTypesUser : emailTypesUserIn,
-                                    emailTypesKeys : emailTypesKeysIn
-                                };
-                            }
-                            return userCurrent;
-                        });
+                    const EMAIL_TYPE_TAGS_EXCLUDED = [
+                        "HIDDEN",
+                        "FORCED",
+                        "ADMIN"
+                    ];
 
-                        return {
-                            emailTypes : emailTypesKeysIn,
-                            fleetUsers
-                        };
-                    });
+                    const prefsByUser = {
+                        ...this.state.prefsByUser,
+                        [userTarget.id]: {
+                        emailTypesUser: response.emailTypesUser,
+                        emailTypesKeys: response.emailTypesKeys.filter(
+                            type => (
+                                EMAIL_TYPE_TAGS_EXCLUDED.every(tag => !type.includes(tag))
+                            )
+                        ),
+                        }
+                    };
+                    
+                    this.setState(prevState => ({
+                        emailTypes: prevState.emailTypes.length
+                                    ? prevState.emailTypes
+                                    : prefsByUser[userTarget.id].emailTypesKeys,
+                        prefsByUser
+                    }));
+
                 },
-                error: (_, __, errorThrown) => console.log("Error getting upset data:", errorThrown)
+                error: (jqXHR, textStatus, errorThrown) => {
+                    
+                    console.log("Error getting upset data:", errorThrown);
+                
+                }
             });
         });
     }
 
     handleCheckboxChange = (userTarget, type) => {
+
         this.setState(
             prevState => {
-                const fleetUsers = prevState.fleetUsers.map(user => {
-                    if (user.id === userTarget.id) {
-                        return {
-                            ...user,
-                            emailTypesUser: {
-                                ...user.emailTypesUser,
-                                [type]: (user.emailTypesUser ? !user.emailTypesUser[type] : false)
-                            }
-                        };
+                const prefsByUser = {
+                    ...prevState.prefsByUser,
+                    [userTarget.id]: {
+                        ...prevState.prefsByUser[userTarget.id],
+                        emailTypesUser: {
+                            ...prevState.prefsByUser[userTarget.id].emailTypesUser,
+                            [type]: !prevState.prefsByUser[userTarget.id].emailTypesUser[type]
+                        }
                     }
-                    return user;
-                });
-                return { fleetUsers };
+                };
+                return { prefsByUser };
             },
-            () => this.updateUserEmailPreferences(userTarget, this.state.fleetUsers)
+            () => this.updateUserEmailPreferences(userTarget, this.state.prefsByUser)
         );
+
     };
 
     refreshFleetUsers = (updatedUsers) => {
         this.setState({ fleetUsers: updatedUsers });
     };
 
-    render() {
-        return (
-            <table style={{ width: "100%", borderCollapse: "collapse" }}>
-                <thead>
-                <tr>
-                    <th style={{padding: "0 12px"}}>Email</th>
-                    {
-                        this.state.emailTypes.map((type, index) => (
-                            <th key={index}>
-                                <div style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    padding: "20px 0px",
-                                    margin: "-7px",
-                                    gap: "8px",
-                                    width: "95%"
-                                }}>
-                                    <ToggleButtonColumnManager
-                                        disableFetching={this.state.disableFetching}
-                                        updateUserEmailPreferences={this.updateUserEmailPreferences}
-                                        fleetUsers={this.state.fleetUsers}
-                                        refreshFleetUsers={this.refreshFleetUsers}
-                                        emailTypes={this.state.emailTypes}
-                                        emailTypeIndex={index}
-                                    />
-                                    {type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
-                                </div>
-                            </th>
-                        ))
-                    }
-                </tr>
-                </thead>
-                <tbody>
-                <tr style={{border: "solid", borderColor: "#00004411", borderWidth: "2px 0px"}}></tr>
-                {
-                    this.state.fleetUsers
-                        .filter(userCurrent => userCurrent.fleetAccess.accessType !== "DENIED")
-                        .map((userCurrent, settingIndex) => {
-                            const rowStyle = {
-                                backgroundColor: (settingIndex % 2 === 0) ? '#FFFFFF00' : '#00000009'
-                            };
+    bulkToggleColumn = (emailType, newValue) => {
 
-                            return (
-                                <tr key={settingIndex} style={{...rowStyle, border: "solid", borderColor: "#00004411", borderWidth: "1px 0px"}}>
-                                    <td style={{padding: "16px 12px"}}>{userCurrent.email}</td>
-                                    {
-                                        this.state.emailTypes.map((type, typeIndex) => (
-                                            <td key={typeIndex}>
-                                                <input
-                                                    type="checkbox"
-                                                    checked={(userCurrent.emailTypesUser && userCurrent.emailTypesUser[type]) ? userCurrent.emailTypesUser[type] : false}
-                                                    onChange={this.state.disableFetching ? () => undefined : () => this.handleCheckboxChange(userCurrent, type)}
-                                                    style={{scale: "2.00"}}
-                                                />
-                                            </td>
-                                        ))
-                                    }
-                                </tr>
-                            );
-                        })
-                }
+        console.log("Bulk toggling email type column: ", emailType, newValue);
+
+        const visibleUsers = this.props.fleetUsers
+            .filter(u => this.props.showDeniedUsers || u.fleetAccess.accessType !== 'DENIED');
+
+        this.setState(prev => {
+
+            const prefsByUser = { ...prev.prefsByUser };
+
+            visibleUsers.forEach(user => {
+                prefsByUser[user.id] = {
+                    ...prefsByUser[user.id],
+                    emailTypesUser: {
+                        ...prefsByUser[user.id].emailTypesUser,
+                        [emailType]: newValue
+                    }
+                };
+            });
+
+            return { prefsByUser };
+
+        }, () => {
+
+            visibleUsers.forEach(u => this.updateUserEmailPreferences(u, this.state.prefsByUser));
+
+        });
+
+    };
+
+    render() {
+
+        const showDeniedUsers = this.props.showDeniedUsers;
+        const fleetUsers = this.props.fleetUsers.filter(u => showDeniedUsers || u.fleetAccess.accessType !== 'DENIED');
+        const prefsByUser = this.state.prefsByUser;
+
+        return (
+            <table className="table-hover rounded-lg w-full">
+                <thead className="leading-16 text-[var(--c_text)] border-b-1">
+                    <tr>
+                        <th className="pl-4">
+                            Email
+                        </th>
+                        {
+                            this.state.emailTypes.map((type, index) => (
+                                <th key={index}>
+                                    <div style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                    }}>
+                                        <ToggleButtonColumnManager
+                                            emailTypes={this.state.emailTypes}
+                                            emailTypeIndex={index}
+                                            fleetUsers={fleetUsers}
+                                            prefsByUser={prefsByUser}
+                                            updateUserEmailPreferences={this.updateUserEmailPreferences}
+                                            disableFetching={this.state.disableFetching}
+                                            bulkToggleColumn={this.bulkToggleColumn}
+                                            showDeniedUsers={showDeniedUsers}
+                                        />
+                                        {type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
+                                    </div>
+                                </th>
+                            ))
+                        }
+                    </tr>
+                </thead>
+
+                <tbody className="text-[var(--c_text)] leading-16 before:content-['\A']">
+             
+                    {/* Empty spacer row */}
+                    <tr className="pointer-none bg-transparent">
+                        <td colSpan={3} className="h-6"/>
+                    </tr>
+
+                    {
+                        fleetUsers
+                            .map((userCurrent, settingIndex) => {
+
+                                const rowClassName = (userCurrent.fleetAccess.accessType==="DENIED" ? `italic opacity-50` : `${settingIndex%2 ? "bg-[var(--c_row_bg)]" : "bg-[var(--c_row_bg_alt)]"}`)
+                                const emailClassName = (userCurrent.fleetAccess.accessType==="DENIED" ? `italic opacity-50` : ``);
+
+                                return (
+                                    <tr key={settingIndex} className={rowClassName}>
+
+                                        {/* Email */}
+                                        <td className={`pl-4 ${emailClassName}`}>
+                                            {userCurrent.email}
+                                        </td>
+
+                                        {/* Email Types */}
+                                        {
+                                            this.state.emailTypes.map((type, typeIndex) => (
+                                                <td key={typeIndex}>
+
+                                                    <div className="flex flex-row gap-2 items-center">
+                                                        <div className="border-l-1 h-12 border-[var(--c_table_border)]"></div>
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={!!prefsByUser[userCurrent.id] && prefsByUser[userCurrent.id].emailTypesUser[type]}
+                                                            onChange={this.state.disableFetching ? () => undefined : () => this.handleCheckboxChange(userCurrent, type)}
+                                                            className="ml-4 !scale-200"
+                                                        />
+                                                    </div>
+
+                                                </td>
+                                            ))
+                                        }
+                                    </tr>
+                                );
+                            })
+                    }
+
+                    {/* Empty spacer row */}
+                    <tr className="pointer-none bg-transparent">
+                        <td colSpan={3} className="h-6"/>
+                    </tr>
+
                 </tbody>
             </table>
         );
     }
+}
+
+
+class ToggleButtonColumnManager extends React.Component {
+
+    /*
+        Button to toggle on/off ALL of the email types in
+        a column for every user in the manager table.
+
+        Directly uses and updates the state of the
+        EmailSettingsTableManager component.
+
+        Based on binary AND of all users' email types in
+        the column.
+    */
+
+    constructor(props) {
+
+        super(props);
+        this.state = {
+            isChecked: false
+        };
+
+    }
+
+    componentDidMount() {
+
+        const { emailTypes, emailTypeIndex, prefsByUser } = this.props;
+        const emailType = emailTypes[emailTypeIndex];
+        const visibleUsers = this.getVisibleUsers();
+
+        //Check if all users have the same preference for this email type
+        const allChecked =
+            (visibleUsers.length > 0)
+            && visibleUsers.every(u => prefsByUser[u.id]?.emailTypesUser[emailType]);
+
+        this.setState({ isChecked: allChecked });
+
+    }
+
+    componentDidUpdate(prevProps) {
+
+        if (prevProps.prefsByUser === this.props.prefsByUser)
+            return;
+
+        const emailType = this.props.emailTypes[this.props.emailTypeIndex];
+        const visibleUsers = this.getVisibleUsers();
+        const allOn =
+            (visibleUsers.length > 0)
+            && visibleUsers.every(u => this.props.prefsByUser[u.id]?.emailTypesUser[emailType]);
+
+        if (allOn !== this.state.isChecked)
+            this.setState({ isChecked: allOn });
+
+    }
+
+    getVisibleUsers = () => {
+
+        return this.props.fleetUsers.filter(u => this.props.showDeniedUsers || u.fleetAccess.accessType !== 'DENIED');
+    
+    };
+
+    handleToggle = () => {
+
+        const { emailTypes, emailTypeIndex } = this.props;
+        const newCheckedState = !this.state.isChecked;
+        const emailType = emailTypes[emailTypeIndex];
+
+        this.setState({ isChecked: newCheckedState });
+
+        this.props.bulkToggleColumn(emailType, newCheckedState);
+
+        const visibleUsers = this.getVisibleUsers();
+        visibleUsers.forEach(user => {
+
+            const updatedSettings = {
+                [user.id]: {
+                    emailTypesUser: {
+                        ...this.props.prefsByUser[user.id].emailTypesUser,
+                        [emailTypes[emailTypeIndex]]: newCheckedState
+                    }
+                }
+            };
+
+            this.props.updateUserEmailPreferences(user, updatedSettings);
+
+        });
+
+    };
+
+    render() {
+
+        const { disableFetching } = this.props;
+        const { isChecked } = this.state;
+
+        return (
+            
+            <button
+                className="ml-4 mr-2"
+                onClick={disableFetching ? () => undefined : this.handleToggle}
+            >
+                <div className="w-8 h-8 flex items-center justify-center rounded-lg bg-[var(--c_tag_badge)]">
+                <i className={`fa fa-${this.state.isChecked ? 'times' : 'check'} text-[var(--c_text)]`}/>
+                </div>
+            </button>
+        );
+    }
+
 }

--- a/ngafid-frontend/src/index.css
+++ b/ngafid-frontend/src/index.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@config "../tailwind.config.js";

--- a/ngafid-frontend/src/metricviewer_preferences.js
+++ b/ngafid-frontend/src/metricviewer_preferences.js
@@ -200,7 +200,7 @@ class MetricViewerSettings extends React.Component {
                     <div className="col" style={{padding:"0 0 0 0"}}>
                         <div className="card card-alt">
                             <h6 className="card-header">
-                                Your Flight Metric Viewer Preferences:
+                                Your Flight Metric Viewer Preferences
                             </h6>
                             <div className="form-group" style={formGroupStyle}>
                             {metricsRow}

--- a/ngafid-frontend/src/preferences_page.js
+++ b/ngafid-frontend/src/preferences_page.js
@@ -92,7 +92,7 @@ class PreferencesPage extends React.Component {
                                     <div className="col" style={{padding:"0 0 0 0"}}>
                                         <div className="card-alt card">
                                             <h6 className="card-header">
-                                                Your Email Preferences:
+                                                Your Email Preferences
                                             </h6>
                                             <div className="form-group my-4 px-4">
                                                 <div className="d-flex">

--- a/ngafid-frontend/src/status_page.tsx
+++ b/ngafid-frontend/src/status_page.tsx
@@ -239,11 +239,11 @@ export default class StatusPage extends React.Component {
                                     return (
                                         <tr key={entry.name} className={`${index%2 ? "bg-[var(--c_row_bg)]" : "bg-[var(--c_row_bg_alt)]"} text-[var(--c_text_alt)]`}>
 
-                                            <td className="w-[10%] max-w-[10%] truncate whitespace-nowrap overflow-hidden">
+                                            <td className="truncate whitespace-nowrap overflow-hidden">
                                                 {index+1} - {entry.nameDisplay}
                                             </td>
 
-                                            <td className="font-mono w-[10%] max-w-[10%] truncate whitespace-nowrap overflow-hidden">
+                                            <td className="font-mono truncate whitespace-nowrap overflow-hidden">
 
                                                 {/* Status Icon */}
                                                 <i className={`mr-2 scale-100 fa ${entry.status.icon}`}/>
@@ -253,7 +253,7 @@ export default class StatusPage extends React.Component {
 
                                             </td>
 
-                                            <td className={`${entry.message == STATUS_DEFAULT_MESSAGE ? "italic opacity-50" : ""} w-[80%] max-w-[80%]`}>
+                                            <td className={`${entry.message == STATUS_DEFAULT_MESSAGE ? "italic opacity-50" : ""}`}>
                                                 {entry.message}
                                             </td>
 

--- a/ngafid-frontend/tailwind.config.js
+++ b/ngafid-frontend/tailwind.config.js
@@ -1,0 +1,5 @@
+// ../tailwind.config.js
+/** @type {import('tailwindcss').Config} */
+export default {
+    content: ["./src/**/*.{html,js,jsx,ts,tsx}"],
+};

--- a/ngafid-frontend/webpack.config.js
+++ b/ngafid-frontend/webpack.config.js
@@ -15,6 +15,36 @@ const doWatch = (!isCI && !isProd);
 const { join } = require('path');
 
 
+
+class ShowChangedFilesPlugin {
+
+    apply(compiler) {
+
+        compiler.hooks.watchRun.tap('ShowChangedFiles', comp => {
+
+            //No files changed, do nothing
+            if (!comp.modifiedFiles || comp.modifiedFiles.length === 0)
+                return;
+
+            //Log the files that changed
+            console.log(
+                '\n\nChanged since last build:',
+                [...comp.modifiedFiles].join(', '),
+                "\n\n"
+            );
+
+        });
+    }
+    
+}
+
+
+
+const outputDir   = path.resolve(__dirname, '../ngafid-static/js');
+const cesiumCache = path.resolve(outputDir, 'cesium');
+const cacheDir    = path.resolve(__dirname, '.webpack_cache');
+
+
 module.exports = {
 
     mode: process.env.NODE_ENV || 'development',
@@ -36,13 +66,15 @@ module.exports = {
     watchOptions: {
         ignored: [
             "/node_modules/",
-            path.resolve(__dirname, "src/main/resources/public/dist/"), //<-- Ignore built files so they aren't recompiled
+            `${outputDir}/**`,
+            `${cesiumCache}/**`,
+            "**/\.webpack_cache/**",
         ],
     },
 
     cache: {
         type: 'filesystem',
-        cacheDirectory: path.resolve(__dirname, '.webpack_cache'),
+        cacheDirectory: cacheDir,
     },
 
     entry: {
@@ -149,6 +181,7 @@ module.exports = {
         new webpack.DefinePlugin({
             CESIUM_BASE_URL: JSON.stringify("/cesium"),
         }),
+        new ShowChangedFilesPlugin(),
     ],
 
 };

--- a/ngafid-www/src/main/java/org/ngafid/www/routes/AccountJavalinRoutes.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/routes/AccountJavalinRoutes.java
@@ -1,8 +1,10 @@
 package org.ngafid.www.routes;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.javalin.Javalin;
 import io.javalin.http.Context;
+
 import org.ngafid.airsync.AirSyncFleet;
 import org.ngafid.core.Database;
 import org.ngafid.core.accounts.*;
@@ -21,6 +23,8 @@ import java.sql.SQLException;
 import java.util.*;
 import java.util.logging.Logger;
 
+import org.apache.kafka.streams.processor.ConnectedStoreProvider;
+import org.ngafid.routes.ErrorResponse;
 import static org.ngafid.www.WebServer.gson;
 
 public class AccountJavalinRoutes {
@@ -574,62 +578,105 @@ public class AccountJavalinRoutes {
 
     }
 
+    @SuppressWarnings("ConvertToStringSwitch")
     private static void postUpdateUserEmailPreferences(Context ctx) {
+
         final User sessionUser = Objects.requireNonNull(ctx.sessionAttribute("user"));
 
-        // Log the raw handleUpdateType value
+        //Add user to / update the UserEmailPreferences map
+        try (Connection connection = Database.getConnection()) {
+
+            UserEmailPreferences.addUser(connection, sessionUser);
+
+        } catch (SQLException e) {
+
+            LOG.severe(e.toString());
+            ctx.json(new ErrorResponse(e)).status(500);
+
+        }
+
+        //Log the raw handleUpdateType value
         final String handleUpdateType = Objects.requireNonNull(ctx.formParam("handleUpdateType"));
 
-        if (handleUpdateType.equals("HANDLE_UPDATE_USER")) { // User Update...
+        //User Update...
+        if (handleUpdateType.equals("HANDLE_UPDATE_USER")) {
+
+            //Unpack Submission Data
             final int userID = sessionUser.getId();
 
-            Map<String, Boolean> emailTypesUser = new HashMap<String, Boolean>();
-            for (String emailKey : ctx.formParamMap().keySet()) {
-                if (emailKey.equals("handleUpdateType")) {
-                    continue;
-                }
+            final HashSet<String> KEYS_EXCLUDE = new HashSet<>(Arrays.asList(
+                "handleUpdateType"
+            ));
 
-                emailTypesUser.put(emailKey, Boolean.parseBoolean(ctx.formParam(emailKey)));
+            Map<String, Boolean> emailTypesUser = new HashMap<>();
+            for (String emailKey : ctx.formParamMap().keySet()) {
+
+                //Skip excluded keys
+                if (KEYS_EXCLUDE.contains(emailKey))
+                    continue;
+
+                emailTypesUser.put(emailKey, Boolean.valueOf(ctx.formParam(emailKey)));
+
             }
 
             try (Connection connection = Database.getConnection()) {
                 ctx.json(User.updateUserEmailPreferences(connection, userID, emailTypesUser));
             } catch (Exception e) {
+                LOG.severe("Error in postUpdateUserEmailPreferences.java (User): " + e.toString());
                 ctx.json(new ErrorResponse(e)).status(500);
             }
-        } else if (handleUpdateType.equals("HANDLE_UPDATE_MANAGER")) { // Manager Update...
-            // Unpack Submission Data
+
+        //Manager Update...
+        } else if (handleUpdateType.equals("HANDLE_UPDATE_MANAGER")) {
+
+            //Unpack Submission Data
             int fleetUserID = Integer.parseInt(Objects.requireNonNull(ctx.formParam("fleetUserID")));
             int fleetID = Integer.parseInt(Objects.requireNonNull(ctx.formParam("fleetID")));
 
-            HashMap<String, Boolean> emailTypesUser = new HashMap<String, Boolean>();
-            for (String emailKey : ctx.formParamMap().keySet()) {
-                if (emailKey.equals("fleetUserID") || emailKey.equals("fleetID") || emailKey.equals("handleUpdateType")) {
-                    continue;
-                }
+            final HashSet<String> KEYS_EXCLUDE = new HashSet<>(Arrays.asList(
+                "fleetUserID",
+                "fleetID",
+                "handleUpdateType"
+            ));
 
-                emailTypesUser.put(emailKey, Boolean.parseBoolean(ctx.formParam(emailKey)));
+            HashMap<String, Boolean> emailTypesUser = new HashMap<>();
+            for (String emailKey : ctx.formParamMap().keySet()) {
+
+                //Skip excluded keys
+                if (KEYS_EXCLUDE.contains(emailKey))
+                    continue;
+
+                emailTypesUser.put(emailKey, Boolean.valueOf(ctx.formParam(emailKey)));
+                
             }
 
-            // Check to see if the logged-in user can update access to this fleet
+            //Check to see if the logged-in user can update access to this fleet
             if (!sessionUser.managesFleet(fleetID)) {
+
                 LOG.severe("INVALID ACCESS: user did not have access to modify user email preferences on this fleet.");
                 ctx.status(401);
                 ctx.result("User did not have access to modify user email preferences on this fleet.");
                 return;
+
             }
 
             try (Connection connection = Database.getConnection()) {
                 ctx.json(User.updateUserEmailPreferences(connection, fleetUserID, emailTypesUser));
             } catch (Exception e) {
+                LOG.severe("Error in postUpdateUserEmailPreferences.java (Manager): " + e.toString());
                 ctx.json(new ErrorResponse(e)).status(500);
             }
+
+        //Unknown Update...
+        } else {
+
+            //ERROR -- Unknown Update!
+            LOG.severe("INVALID ACCESS: handleUpdateType not specified.");
+            ctx.status(401);
+            ctx.result("handleUpdateType not specified.");
+
         }
 
-        // ERROR -- Unknown Update!
-        LOG.severe("INVALID ACCESS: handleUpdateType not specified.");
-        ctx.status(401);
-        ctx.result("handleUpdateType not specified.");
     }
 
     private static void getEmailUnsubscribe(Context ctx) {


### PR DESCRIPTION
* Fix for webpack compiling in an infinite loop

---

* Fix for email prefs not getting updated correctly (when User is not already cached before trying to update an email preference)

---

* UI & functionality fixes for the Manage Fleet page
* Access Level state will now properly update (without having to refresh)
* The User will not be able to change their own Access Level (which could have resulted in them getting locked out of their own Fleet)
* Denied users are now properly hidden from the Email Settings table (also are ignored by mass-toggle checkboxes if hidden)
* Gray out / italicize denied users when denied users are shown
* Shows placeholder for missing Name in Fleet Access table
* Other misc visual changes

![image](https://github.com/user-attachments/assets/58bf155f-1f4e-49cd-a7c0-f9bddd9064db)
![image](https://github.com/user-attachments/assets/3ba4d104-6050-4455-aca4-e1da68d46ac9)

---

* Small UI changes for the preferences page
* New badges for email prefs buttons

![image](https://github.com/user-attachments/assets/c60fc330-8dcb-4c60-a003-011f18d93c81)


