### PR TITLE
Use correct variable to render airframe name in Flights page

### DIFF
--- a/ngafid-frontend/src/flight_component.js
+++ b/ngafid-frontend/src/flight_component.js
@@ -1329,6 +1329,8 @@ class Flight extends React.Component {
             $('[data-bs-toggle="tooltip"]').tooltip()
         })
 
+        //  console.log("Rendering Airframe Component: ", flightInfo);
+
         return (
             <div className="card mb-1" style={{backgroundColor:"var(--c_entry_bg)"}}>
                 <div className="">
@@ -1375,8 +1377,8 @@ class Flight extends React.Component {
                                         <div>
                                             ◦&nbsp;
                                             {
-                                                (flightInfo.airframeName!=null && flightInfo.airframeName!="")
-                                                ? <a>{flightInfo.airframeName}</a>
+                                                (flightInfo.airframe.name!=null && flightInfo.airframe.name!="")
+                                                ? <a>{flightInfo.airframe.name}</a>
                                                 : <a style={styleEmptyCell}>No Airframe Name...</a>
                                             }
                                         </div>


### PR DESCRIPTION
Hotfix: `airframeName` --> `airframe.name`

![image](https://github.com/user-attachments/assets/2a1e5d1b-5127-4938-848b-9bf46bf5b3d9)
