### PR TITLE
Addressed proximity bugs, needs testing

### DIFF
--- a/ngafid-data-processor/src/main/java/org/ngafid/processor/events/proximity/FlightTimeLocation.java
+++ b/ngafid-data-processor/src/main/java/org/ngafid/processor/events/proximity/FlightTimeLocation.java
@@ -5,7 +5,6 @@ import org.ngafid.core.flights.Flight;
 import org.ngafid.core.flights.Parameters;
 import org.ngafid.core.flights.StringTimeSeries;
 import org.ngafid.core.util.filters.Pair;
-import org.ngafid.processor.format.CSVFileProcessor;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -173,9 +172,6 @@ public final class FlightTimeLocation {
         LOG.info("Buffered overlap check: " + overlap);
         return overlap;
     }
-
-
-
 
 
     public boolean isValid() {

--- a/ngafid-data-processor/src/main/java/org/ngafid/processor/events/proximity/FlightTimeLocation.java
+++ b/ngafid-data-processor/src/main/java/org/ngafid/processor/events/proximity/FlightTimeLocation.java
@@ -172,7 +172,7 @@ public final class FlightTimeLocation {
 
         boolean overlap = thisToOther || otherToThis;
 
-        LOG.info("Buffered overlap check: " + overlap);
+        LOG.info("Overlap check: " + overlap);
         return overlap;
     }
 

--- a/ngafid-data-processor/src/main/java/org/ngafid/processor/events/proximity/ProximityEventScanner.java
+++ b/ngafid-data-processor/src/main/java/org/ngafid/processor/events/proximity/ProximityEventScanner.java
@@ -70,7 +70,7 @@ public class ProximityEventScanner extends AbstractEventScanner {
         // Expands the bounding box to address edge cases.
         final double DEGREE_BUFFER = 0.003; // 1000 ft
 
-        if (!flightInfo.hasBufferedRegionOverlap(otherFlightInfo, DEGREE_BUFFER) ||
+        if (!flightInfo.hasRegionOverlap(otherFlightInfo, DEGREE_BUFFER) ||
                 !otherFlightInfo.getSeriesData(connection)) {
             return List.of();
         }
@@ -256,12 +256,11 @@ public class ProximityEventScanner extends AbstractEventScanner {
 
         List<Event> allEvents = new ArrayList<>();
         for (Flight otherFlight : potentialFlights) {
-            if (otherFlight.getId() == flight.getId()) continue; // prevent self comparison
+            if (otherFlight.getId() <= flight.getId()) continue; // skip self or already-compared flight pairs
             LOG.info("Scanning flight pair");
             FlightTimeLocation otherFlightInfo = new FlightTimeLocation(connection, otherFlight);
             allEvents.addAll(scanFlightPair(connection, flight, flightInfo, otherFlight, otherFlightInfo));
         }
-
         return allEvents;
     }
 

--- a/ngafid-data-processor/src/main/java/org/ngafid/processor/events/proximity/ProximityEventScanner.java
+++ b/ngafid-data-processor/src/main/java/org/ngafid/processor/events/proximity/ProximityEventScanner.java
@@ -256,7 +256,7 @@ public class ProximityEventScanner extends AbstractEventScanner {
 
         List<Event> allEvents = new ArrayList<>();
         for (Flight otherFlight : potentialFlights) {
-            if (otherFlight.getId() == flight.getId()) continue;
+            if (otherFlight.getId() == flight.getId()) continue; // prevent self comparison
             LOG.info("Scanning flight pair");
             FlightTimeLocation otherFlightInfo = new FlightTimeLocation(connection, otherFlight);
             allEvents.addAll(scanFlightPair(connection, flight, flightInfo, otherFlight, otherFlightInfo));

--- a/ngafid-data-processor/src/test/java/proximity/ProximityTest.java
+++ b/ngafid-data-processor/src/test/java/proximity/ProximityTest.java
@@ -1,0 +1,116 @@
+package proximity;
+
+import org.junit.Test;
+import org.ngafid.processor.events.proximity.FlightTimeLocation;
+
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ProximityTest {
+
+    private FlightTimeLocation createFlight(double minLat, double maxLat,
+                                            double minLon, double maxLon) {
+        return new FlightTimeLocation(minLat, maxLat, minLon, maxLon);
+    }
+
+    @Test
+    public void shouldReturnFalse_whenNoOverlapWithoutBuffer() {
+        FlightTimeLocation a = createFlight(10, 12, 10, 12);
+        FlightTimeLocation b = createFlight(12.1, 13, 12.1, 13);
+
+        assertFalse(a.hasRegionOverlap(b,0));
+        assertFalse(b.hasRegionOverlap(a,0));
+    }
+
+    @Test
+    public void shouldReturnTrue_whenOverlapWithoutBuffer()  {
+        FlightTimeLocation a = createFlight(10, 12, 10, 12);
+        FlightTimeLocation b = createFlight(11, 13, 11, 13);
+
+        assertTrue(a.hasRegionOverlap(b,0));
+        assertTrue(b.hasRegionOverlap(a,0));
+
+    }
+
+    @Test
+    public void shouldReturnTrue_whenBufferTouchesEdges() throws SQLException {
+        FlightTimeLocation a = createFlight(10, 12, 10, 12);
+        FlightTimeLocation b = createFlight(12.5, 14, 12.5, 14);
+
+        // With buffer, b should now overlap a
+        assertTrue(a.hasRegionOverlap(b,0.5));
+        assertTrue(b.hasRegionOverlap(a,0.5));
+    }
+
+    @Test
+    public void shouldReturnTrue_whenEdgesTouchExactly()  {
+        FlightTimeLocation a = createFlight(10, 12, 10, 12);
+        FlightTimeLocation b = createFlight(12, 14, 12, 14);
+
+        assertTrue(a.hasRegionOverlap(b, 0));
+        assertTrue(b.hasRegionOverlap(a, 0));
+    }
+
+    @Test
+    public void shouldReturnFalse_whenJustOutsideWithoutBuffer() {
+        FlightTimeLocation a = createFlight(10, 12, 10, 12);
+        FlightTimeLocation b = createFlight(12.01, 14, 12.01, 14);
+
+        assertFalse(a.hasRegionOverlap(b, 0));
+        assertFalse(b.hasRegionOverlap(a, 0));
+    }
+
+    @Test
+    public void shouldReturnTrue_whenRegionIsFullyContainedWithinAnother() {
+        FlightTimeLocation outer = createFlight(10, 20, 10, 20);
+        FlightTimeLocation inner = createFlight(12, 18, 12, 18);
+
+        assertTrue(outer.hasRegionOverlap(inner, 0));
+        assertTrue(inner.hasRegionOverlap(outer, 0));
+    }
+
+    @Test
+    public void shouldReturnTrue_whenRegionsAreIdentical() {
+        FlightTimeLocation a = createFlight(10, 20, 10, 20);
+        FlightTimeLocation b = createFlight(10, 20, 10, 20);
+
+        assertTrue(a.hasRegionOverlap(b, 0));
+        assertTrue(b.hasRegionOverlap(a, 0));
+    }
+
+    @Test
+    public void testNegativeCoordinatesOverlap() throws SQLException {
+        FlightTimeLocation a = createFlight(-5, -3, -5, -3);
+        FlightTimeLocation b = createFlight(-4, -2, -4, -2);
+
+        assertTrue(a.hasRegionOverlap(b,0));
+    }
+
+    @Test
+    public void testNoOverlapEvenWithBuffer() throws SQLException {
+        FlightTimeLocation a = createFlight(0, 1, 0, 1);
+        FlightTimeLocation b = createFlight(5, 6, 5, 6);
+
+        assertFalse(a.hasRegionOverlap(b,0));
+    }
+
+    @Test
+    public void shouldReturnTrue_whenNegativeRegionsOverlap() {
+        FlightTimeLocation a = createFlight(-5, -3, -5, -3);
+        FlightTimeLocation b = createFlight(-4, -2, -4, -2);
+
+        assertTrue(a.hasRegionOverlap(b, 0));
+        assertTrue(b.hasRegionOverlap(a, 0));
+    }
+
+    @Test
+    public void shouldReturnFalse_whenRegionsAreFarApartEvenWithBuffer() {
+        FlightTimeLocation a = createFlight(0, 1, 0, 1);
+        FlightTimeLocation b = createFlight(5, 6, 5, 6);
+
+        assertFalse(a.hasRegionOverlap(b, 1.0));
+        assertFalse(b.hasRegionOverlap(a, 1.0));
+    }
+}

--- a/ngafid-data-processor/src/test/java/proximity/ProximityTest.java
+++ b/ngafid-data-processor/src/test/java/proximity/ProximityTest.java
@@ -81,7 +81,7 @@ public class ProximityTest {
     }
 
     @Test
-    public void testNegativeCoordinatesOverlap() throws SQLException {
+    public void testNegativeCoordinatesOverlap() {
         FlightTimeLocation a = createFlight(-5, -3, -5, -3);
         FlightTimeLocation b = createFlight(-4, -2, -4, -2);
 
@@ -89,7 +89,7 @@ public class ProximityTest {
     }
 
     @Test
-    public void testNoOverlapEvenWithBuffer() throws SQLException {
+    public void testNoOverlapEvenWithBuffer() {
         FlightTimeLocation a = createFlight(0, 1, 0, 1);
         FlightTimeLocation b = createFlight(5, 6, 5, 6);
 


### PR DESCRIPTION
This pull request addressed issues described in a message from Travis:

1. When doing the querying by the min/max lat/lon bounds for other potential proximity flights, make sure to increase the max and decrease the min by the proximity maximum value (e.g., 1000ft) - this captures edge cases where the min/max boxes for flights don't overlap but they still come within however many feet of each other

2. Update the required columns to not only be for fixed wing aircraft.  I think we can just require AltAGL > 50 ft (we should discuss and bring up on the thursday meeting) -- we need to make sure we can capture prox events between fixed wing and UAS or rotorcraft still show up

3 Make sure whatever was causing flights to have prox events with themselves is fixed