### PR TITLE
Fixed a bug that caused incorrect proximity event insertions into dat…

### DIFF
--- a/ngafid-data-processor/pom.xml
+++ b/ngafid-data-processor/pom.xml
@@ -41,41 +41,39 @@
         </dependency>
 
 
-        <!-- Parquet file processor -->
-        <!-- Parquet with Avro support -->
+        <!-- Parquet Reader Support -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>1.13.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
             <version>1.13.1</version>
         </dependency>
 
-        <!-- Apache Avro for GenericRecord -->
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>1.11.1</version>
-        </dependency>
-
+        <!-- Hadoop Core -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>3.3.6</version>
-            <scope>compile</scope>
         </dependency>
 
+        <!-- Hadoop MapReduce Client -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>3.3.6</version>
+        </dependency>
 
-        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+        <!-- IO Utilities -->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.18.0</version>
         </dependency>
-
-        <!--End Parquet Processor dependency-->
-
-
-
-
 
     </dependencies>
 


### PR DESCRIPTION
This PR fixes a bug that caused proximity events with the same flight_id and other_flight_id to be inserted into the database.

The issue was in Event.java — specifically in the addBatch call during batch insertion. Instead of using event.flightId, the code mistakenly used flight.getId(), which is incorrect for proximity event pairs where each Event represents a different flight.

Refactored the addBatch method to use a simpler and safer signature that relies on the internal state of the Event object.
Updated all relevant method calls to use the new signature and fixed the incorrect flight ID usage.

<img width="1186" alt="Screenshot 2025-06-21 at 6 25 30 PM" src="https://github.com/user-attachments/assets/999f6bc8-8f83-459f-b121-5ba8a3cbb960" />


