### PR TITLE
View / Clear replay button (temporary) fixes

### DIFF
--- a/src/main/javascript/flight.js
+++ b/src/main/javascript/flight.js
@@ -509,21 +509,6 @@ class FlightPage extends React.Component {
                           () => {this.removeTag(flightId, -2, false)});
     }
 
-    /**
-     * Handles clearing all selected flights for multiple flight replays
-     */
-     clearCesiumFlights() {
-         cesiumFlightsSelected.forEach((removedFlight) => {
-             console.log("Removed " + removedFlight);
-             let toggleButton = document.getElementById("cesiumToggled" + removedFlight);
-             toggleButton.click();
-         });
-
-         if (cesiumFlightsSelected.length > 0) {
-             this.clearCesiumFlights();
-         }
-    }
-
     displayPlot() {
 
         let styles = getComputedStyle(document.documentElement);

--- a/src/main/javascript/flight_component.js
+++ b/src/main/javascript/flight_component.js
@@ -23,7 +23,8 @@ import { selectAircraftModal } from './select_acft_modal.js';
 import {generateLOCILayer, generateStallLayer} from './map_utils.js';
 
 import Plotly from 'plotly.js';
-import {cesiumFlightsSelected, updateCesiumButtonState} from "./cesium_buttons";
+import {cesiumFlightsSelected, updateCesiumButtonState, toggleCesiumFlightSelected, cesiumFlightIsSelected} from "./cesium_buttons";
+import { glob } from 'fs';
 
 var moment = require('moment');
 
@@ -996,12 +997,12 @@ class Flight extends React.Component {
 
         //console.log(flightInfo);
         if (!flightInfo.hasCoords) {
-            //console.log("flight " + flightInfo.id + " doesn't have coords!");
-            globeClasses += " disabled";
+            console.log("flight " + flightInfo.id + " doesn't have coords!");
+            // globeClasses += " disabled";
             globeTooltip = "Cannot display flight on the map because the flight data did not have latitude/longitude.";
             traceDisabled = true;
         } else {
-            globeTooltip = "Click the globe to display the flight on the map.";
+            globeTooltip = "Click the globe to add as a selected replay.";
         }
 
         let visitedAirports = [];
@@ -1188,7 +1189,15 @@ class Flight extends React.Component {
                                         </div>
 
                                         <div className={"d-flex flex-row ml-auto mr-auto"} style={{flexShrink:"1", gap:"0.25em"}}>
-                                            <button className={buttonClasses + globeClasses} style={styleButton} title={globeTooltip} id={"cesiumToggled" + this.props.flightInfo.id} data-toggle="button" aria-pressed={this.state.replayToggled} style={styleButton} onClick={() => this.cesiumClicked()}>
+                                            <button
+                                                className={`${buttonClasses} ${cesiumFlightIsSelected(this.props.flightInfo.id) ? "active" : ""} ${globeClasses}`}
+                                                style={styleButton}
+                                                id={"cesiumToggled" + this.props.flightInfo.id}
+                                                data-toggle="button"
+                                                aria-pressed={this.state.replayToggled}
+                                                aria-label={globeTooltip}
+                                                onClick={() => toggleCesiumFlightSelected(this.props.flightInfo.id)}
+                                            >
                                                 <i className="fa fa-globe p-1"></i>
                                             </button>
 

--- a/src/main/javascript/flights.js
+++ b/src/main/javascript/flights.js
@@ -1278,22 +1278,6 @@ class FlightsPage extends React.Component {
 	);
   }
 
-  /**
-   * Handles clearing all selected flights for multiple flight replays
-   */
-  clearCesiumFlights() {
-	cesiumFlightsSelected.forEach((removedFlight) => {
-  	console.log("Removed " + removedFlight);
-  	let toggleButton = document.getElementById(
-    	"cesiumToggled" + removedFlight
-  	);
-  	toggleButton.click();
-	});
-
-	if (cesiumFlightsSelected.length > 0) {
-  	this.clearCesiumFlights();
-	}
-  }
 
 	displayPlot() {
 


### PR DESCRIPTION
Returns functionality to the View & Clear Selected Replay buttons.

This functionality will no longer be needed when the embedded Cesium page eventually makes it to stable.

Click the Globe icons for a flight to add it as a selected replay. All currently selected flight IDs will be displayed in a URL hash, e.g.
![image](https://github.com/user-attachments/assets/1dc27e78-0988-43ec-9ece-6a838ff28761)

Then, just click the View Selected Replays button and it should 🙏 just open the Cesium page like normal with the selected flights.