### PR TITLE
Roman/feature/javadoc GitHub pages

### DIFF
--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -48,8 +48,8 @@ jobs:
             
       - name: Build and Generate JavaDoc
         run: |
-          # First compile all modules to resolve dependencies
-          mvn clean compile -DskipTests
+          # First install all modules to resolve dependencies
+          mvn clean install -DskipTests
           # Then generate JavaDoc for all modules
           mvn javadoc:javadoc -DskipTests
           # Create a combined JavaDoc site

--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -33,9 +33,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           
-      - name: Setup DAT2CSV
-        run: run/setup_dat_importing
-        
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
@@ -43,6 +40,11 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-m2-
+            
+      - name: Setup DAT2CSV
+        run: |
+          # Install the local DAT2CSV JAR file into Maven repository
+          mvn install:install-file -Dfile=resources/DAT2CSV-1.0.jar -DgroupId=org.ngafid -DartifactId=dat2csv -Dpackaging=jar -Dversion=1.0
             
       - name: Generate JavaDoc
         run: |

--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -1,5 +1,8 @@
 name: Publish JavaDoc to GitHub Pages
 
+# IMPORTANT: Make sure GitHub Pages is configured to use "GitHub Actions" as source
+# Go to Settings → Pages → Source → Select "GitHub Actions"
+
 on:
   push:
     branches: [ main, roman/feature/javadoc-github-pages ]
@@ -79,3 +82,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
       - name: Checkout
@@ -37,8 +40,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-kotlin-2.0.21
           restore-keys: |
+            ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-
             ${{ runner.os }}-m2-
             
       - name: Setup DAT2CSV

--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -46,9 +46,12 @@ jobs:
           # Install the local DAT2CSV JAR file into Maven repository
           mvn install:install-file -Dfile=resources/DAT2CSV-1.0.jar -DgroupId=org.ngafid -DartifactId=dat2csv -Dpackaging=jar -Dversion=1.0
             
-      - name: Generate JavaDoc
+      - name: Build and Generate JavaDoc
         run: |
-          mvn clean javadoc:javadoc -DskipTests
+          # First compile all modules to resolve dependencies
+          mvn clean compile -DskipTests
+          # Then generate JavaDoc for all modules
+          mvn javadoc:javadoc -DskipTests
           # Create a combined JavaDoc site
           mkdir -p target/site/javadoc
           echo "<html><head><title>NGAFID 2.0 JavaDoc</title></head><body>" > target/site/javadoc/index.html

--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -5,7 +5,7 @@ name: Publish JavaDoc to GitHub Pages
 
 on:
   push:
-    branches: [ main, roman/feature/javadoc-github-pages ]
+    branches: [ main ]
     paths:
       - '**/*.java'
       - '**/*.kt'

--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -2,7 +2,7 @@ name: Publish JavaDoc to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, roman/feature/javadoc-github-pages ]
     paths:
       - '**/*.java'
       - '**/*.kt'

--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -1,0 +1,72 @@
+name: Publish JavaDoc to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.java'
+      - '**/*.kt'
+      - '**/pom.xml'
+      - '.github/workflows/javadoc-publish.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          
+      - name: Setup DAT2CSV
+        run: run/setup_dat_importing
+        
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
+            
+      - name: Generate JavaDoc
+        run: |
+          mvn clean javadoc:javadoc -DskipTests
+          # Create a combined JavaDoc site
+          mkdir -p target/site/javadoc
+          echo "<html><head><title>NGAFID 2.0 JavaDoc</title></head><body>" > target/site/javadoc/index.html
+          echo "<h1>NGAFID 2.0 JavaDoc</h1>" >> target/site/javadoc/index.html
+          echo "<ul>" >> target/site/javadoc/index.html
+          echo "<li><a href='ngafid-core/'>ngafid-core</a></li>" >> target/site/javadoc/index.html
+          echo "<li><a href='ngafid-www/'>ngafid-www</a></li>" >> target/site/javadoc/index.html
+          echo "<li><a href='ngafid-data-processor/'>ngafid-data-processor</a></li>" >> target/site/javadoc/index.html
+          echo "<li><a href='ngafid-db/'>ngafid-db</a></li>" >> target/site/javadoc/index.html
+          echo "<li><a href='ngafid-airsync/'>ngafid-airsync</a></li>" >> target/site/javadoc/index.html
+          echo "</ul></body></html>" >> target/site/javadoc/index.html
+          
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/site/javadoc
+          
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/javadoc-test.yml
+++ b/.github/workflows/javadoc-test.yml
@@ -42,12 +42,25 @@ jobs:
           mvn clean install -DskipTests
           mvn javadoc:javadoc -DskipTests
           echo "✅ JavaDoc generation test completed successfully!"
-          echo "📁 Generated files in target/site/javadoc/"
+          
+          # Check what was actually generated
+          echo "📁 Checking generated files..."
+          find . -name "*.html" -path "*/target/*" | head -10
+          echo "📁 Checking target directories..."
+          find . -name "target" -type d
+          echo "📁 Checking if javadoc directory exists..."
+          ls -la target/site/ 2>/dev/null || echo "target/site/ not found"
+          ls -la target/site/javadoc/ 2>/dev/null || echo "target/site/javadoc/ not found"
+          
           echo "🚀 Ready for merge to main branch for production deployment"
           
       - name: Upload JavaDoc as Artifact
         uses: actions/upload-artifact@v4
         with:
           name: javadoc-test
-          path: target/site/javadoc
+          path: |
+            target/site/javadoc
+            target/site
+            target
           retention-days: 7
+        continue-on-error: true

--- a/.github/workflows/javadoc-test.yml
+++ b/.github/workflows/javadoc-test.yml
@@ -2,28 +2,28 @@ name: Test JavaDoc Generation
 
 on:
   push:
-    branches: [ roman/feature/javadoc-github-pages, aidan_cu/main_july2025 ]
+    branches: [roman/feature/javadoc-github-pages, aidan_cu/main_july2025]
     paths:
-      - '**/*.java'
-      - '**/*.kt'
-      - '**/pom.xml'
-      - '.github/workflows/javadoc-test.yml'
+      - "**/*.java"
+      - "**/*.kt"
+      - "**/pom.xml"
+      - ".github/workflows/javadoc-test.yml"
   workflow_dispatch:
 
 jobs:
   test-javadoc:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
-          
+          java-version: "21"
+          distribution: "temurin"
+
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
@@ -32,20 +32,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-
             ${{ runner.os }}-m2-
-            
+
       - name: Setup DAT2CSV
         run: |
           mvn install:install-file -Dfile=resources/DAT2CSV-1.0.jar -DgroupId=org.ngafid -DartifactId=dat2csv -Dpackaging=jar -Dversion=1.0
-            
+
       - name: Build and Generate JavaDoc (Test Only)
         run: |
-          mvn clean install -DskipTests
-          
+          set -euo pipefail
+          mvn -B -ntp clean install -DskipTests
+              
           echo "Running JavaDoc generation with verbose output..."
-          mvn javadoc:javadoc -DskipTests -X | grep -E "(javadoc|target|html)" || echo "No javadoc output found"
-          
+          mvn -B -ntp -DskipTests javadoc:javadoc -X
+
           echo "JavaDoc generation test completed!"
-          
+
           # Check what was actually generated
           echo "Checking generated files..."
           find . -name "*.html" -path "*/target/*" | head -10
@@ -54,21 +55,46 @@ jobs:
           echo "Checking if apidocs directory exists..."
           ls -la target/site/ 2>/dev/null || echo "target/site/ not found"
           ls -la target/site/apidocs/ 2>/dev/null || echo "target/site/apidocs/ not found"
-          
+
+          # Stage per-module outputs (under target/site/javadoc/<module>/)
+          PUBDIR=target/site/javadoc
+          rm -rf "$PUBDIR" && mkdir -p "$PUBDIR"
+          for module in ngafid-core ngafid-www ngafid-data-processor ngafid-db ngafid-airsync; do
+            if [ -d "$module/target/site/apidocs" ]; then
+              mkdir -p "$PUBDIR/$module"
+              cp -r "$module/target/site/apidocs/"* "$PUBDIR/$module"/
+            fi
+          done
+
           # Check if any JavaDoc was generated at all
           echo "Checking for any JavaDoc files..."
           find . -name "*.html" | grep -i javadoc || echo "No JavaDoc HTML files found"
           find . -name "*.html" | head -5 || echo "No HTML files found at all"
-          
+
+          # Create index for browsing the different modules
+          cat > "$PUBDIR/index.html" << 'HTML'
+          <!DOCTYPE html>
+          <meta charset="utf-8">
+          <title>NGAFID JavaDoc</title>
+          <h1>NGAFID JavaDoc</h1>
+          <ul>
+            <li><a href="ngafid-core/">ngafid-core</a></li>
+            <li><a href="ngafid-www/">ngafid-www</a></li>
+            <li><a href="ngafid-data-processor/">ngafid-data-processor</a></li>
+            <li><a href="ngafid-db/">ngafid-db</a></li>
+            <li><a href="ngafid-airsync/">ngafid-airsync</a></li>
+          </ul>
+          HTML
+
+          # Explicit check for the generated HTML file
+          test -f target/site/javadoc/index.html
+
           echo "Ready for merge to main branch for production deployment"
-          
+
       - name: Upload JavaDoc as Artifact
         uses: actions/upload-artifact@v4
         with:
           name: javadoc-test
-          path: |
-            **/target/site/apidocs
-            **/target/site
-            target
+          path: target/site/javadoc
           retention-days: 7
         continue-on-error: true

--- a/.github/workflows/javadoc-test.yml
+++ b/.github/workflows/javadoc-test.yml
@@ -1,0 +1,53 @@
+name: Test JavaDoc Generation
+
+on:
+  push:
+    branches: [ roman/feature/javadoc-github-pages ]
+    paths:
+      - '**/*.java'
+      - '**/*.kt'
+      - '**/pom.xml'
+      - '.github/workflows/javadoc-test.yml'
+  workflow_dispatch:
+
+jobs:
+  test-javadoc:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-kotlin-2.0.21
+          restore-keys: |
+            ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-
+            ${{ runner.os }}-m2-
+            
+      - name: Setup DAT2CSV
+        run: |
+          mvn install:install-file -Dfile=resources/DAT2CSV-1.0.jar -DgroupId=org.ngafid -DartifactId=dat2csv -Dpackaging=jar -Dversion=1.0
+            
+      - name: Build and Generate JavaDoc (Test Only)
+        run: |
+          mvn clean install -DskipTests
+          mvn javadoc:javadoc -DskipTests
+          echo "✅ JavaDoc generation test completed successfully!"
+          echo "📁 Generated files in target/site/javadoc/"
+          echo "🚀 Ready for merge to main branch for production deployment"
+          
+      - name: Upload JavaDoc as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: javadoc-test
+          path: target/site/javadoc
+          retention-days: 7

--- a/.github/workflows/javadoc-test.yml
+++ b/.github/workflows/javadoc-test.yml
@@ -2,7 +2,7 @@ name: Test JavaDoc Generation
 
 on:
   push:
-    branches: [ roman/feature/javadoc-github-pages ]
+    branches: [ roman/feature/javadoc-github-pages, aidan_cu/main_july2025 ]
     paths:
       - '**/*.java'
       - '**/*.kt'
@@ -41,26 +41,26 @@ jobs:
         run: |
           mvn clean install -DskipTests
           
-          echo "🔍 Running JavaDoc generation with verbose output..."
+          echo "Running JavaDoc generation with verbose output..."
           mvn javadoc:javadoc -DskipTests -X | grep -E "(javadoc|target|html)" || echo "No javadoc output found"
           
-          echo "✅ JavaDoc generation test completed!"
+          echo "JavaDoc generation test completed!"
           
           # Check what was actually generated
-          echo "📁 Checking generated files..."
+          echo "Checking generated files..."
           find . -name "*.html" -path "*/target/*" | head -10
-          echo "📁 Checking target directories..."
+          echo "Checking target directories..."
           find . -name "target" -type d
-          echo "📁 Checking if apidocs directory exists..."
+          echo "Checking if apidocs directory exists..."
           ls -la target/site/ 2>/dev/null || echo "target/site/ not found"
           ls -la target/site/apidocs/ 2>/dev/null || echo "target/site/apidocs/ not found"
           
           # Check if any JavaDoc was generated at all
-          echo "📁 Checking for any JavaDoc files..."
+          echo "Checking for any JavaDoc files..."
           find . -name "*.html" | grep -i javadoc || echo "No JavaDoc HTML files found"
           find . -name "*.html" | head -5 || echo "No HTML files found at all"
           
-          echo "🚀 Ready for merge to main branch for production deployment"
+          echo "Ready for merge to main branch for production deployment"
           
       - name: Upload JavaDoc as Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/javadoc-test.yml
+++ b/.github/workflows/javadoc-test.yml
@@ -51,9 +51,9 @@ jobs:
           find . -name "*.html" -path "*/target/*" | head -10
           echo "📁 Checking target directories..."
           find . -name "target" -type d
-          echo "📁 Checking if javadoc directory exists..."
+          echo "📁 Checking if apidocs directory exists..."
           ls -la target/site/ 2>/dev/null || echo "target/site/ not found"
-          ls -la target/site/javadoc/ 2>/dev/null || echo "target/site/javadoc/ not found"
+          ls -la target/site/apidocs/ 2>/dev/null || echo "target/site/apidocs/ not found"
           
           # Check if any JavaDoc was generated at all
           echo "📁 Checking for any JavaDoc files..."
@@ -67,8 +67,8 @@ jobs:
         with:
           name: javadoc-test
           path: |
-            target/site/javadoc
-            target/site
+            **/target/site/apidocs
+            **/target/site
             target
           retention-days: 7
         continue-on-error: true

--- a/.github/workflows/javadoc-test.yml
+++ b/.github/workflows/javadoc-test.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Build and Generate JavaDoc (Test Only)
         run: |
           mvn clean install -DskipTests
-          mvn javadoc:javadoc -DskipTests
-          echo "✅ JavaDoc generation test completed successfully!"
+          
+          echo "🔍 Running JavaDoc generation with verbose output..."
+          mvn javadoc:javadoc -DskipTests -X | grep -E "(javadoc|target|html)" || echo "No javadoc output found"
+          
+          echo "✅ JavaDoc generation test completed!"
           
           # Check what was actually generated
           echo "📁 Checking generated files..."
@@ -51,6 +54,11 @@ jobs:
           echo "📁 Checking if javadoc directory exists..."
           ls -la target/site/ 2>/dev/null || echo "target/site/ not found"
           ls -la target/site/javadoc/ 2>/dev/null || echo "target/site/javadoc/ not found"
+          
+          # Check if any JavaDoc was generated at all
+          echo "📁 Checking for any JavaDoc files..."
+          find . -name "*.html" | grep -i javadoc || echo "No JavaDoc HTML files found"
+          find . -name "*.html" | head -5 || echo "No HTML files found at all"
           
           echo "🚀 Ready for merge to main branch for production deployment"
           

--- a/.github/workflows/javadoc-test.yml
+++ b/.github/workflows/javadoc-test.yml
@@ -57,32 +57,59 @@ jobs:
           ls -la target/site/apidocs/ 2>/dev/null || echo "target/site/apidocs/ not found"
 
           # Stage per-module outputs (under target/site/javadoc/<module>/)
-          PUBDIR=target/site/javadoc
-          rm -rf "$PUBDIR" && mkdir -p "$PUBDIR"
-          for module in ngafid-core ngafid-www ngafid-data-processor ngafid-db ngafid-airsync; do
-            if [ -d "$module/target/site/apidocs" ]; then
-              mkdir -p "$PUBDIR/$module"
-              cp -r "$module/target/site/apidocs/"* "$PUBDIR/$module"/
+          PUBDIR="target/site/javadoc"
+          rm -rf "$PUBDIR"
+          mkdir -p "$PUBDIR"
+
+          modules=(ngafid-core ngafid-www ngafid-data-processor ngafid-airsync ngafid-db)
+
+          for module in "${modules[@]}"; do
+            src="$module/target/site/apidocs"
+            dest="$PUBDIR/$module"
+
+            # Directory exists, count the HTML files
+            if [[ -d "$src" ]]; then
+              mkdir -p "$dest"
+              # Copy even when directory only has subdirectories/dotfiles
+              cp -R "$src"/. "$dest"/ || true
+              count=$(find "$dest" -type f -name '*.html' | wc -l | tr -d '[:space:]')
+            else
+              count=0
+            fi
+
+            # Got HTML files for this module, record it for the index
+            if [[ "$count" -gt 0 ]]; then
+              echo "Staged: $module ($count html files)"
+              index_items+=("  <li><a href=\"$module/\">$module</a> <small>($count files)</small></li>")
+            # Otherwise, record it as missing
+            else
+              echo "Skip: $module (no docs)"
+              # Non-clickable, struck-through entry
+              index_items+=("  <li><span class=\"missing\" title=\"No Javadoc found\">$module</span></li>")
             fi
           done
 
           # Create landing page index file for browsing the different modules
-          cat > "$PUBDIR/index.html" << 'HTML'
-          <!DOCTYPE html>
-          <meta charset="utf-8">
-          <title>NGAFID JavaDoc</title>
-          <h1>NGAFID JavaDoc</h1>
-          <ul>
-            <li><a href="ngafid-core/">ngafid-core</a></li>
-            <li><a href="ngafid-www/">ngafid-www</a></li>
-            <li><a href="ngafid-data-processor/">ngafid-data-processor</a></li>
-            <li><a href="ngafid-db/">ngafid-db</a></li>
-            <li><a href="ngafid-airsync/">ngafid-airsync</a></li>
-          </ul>
-          HTML
+          # (Modules without any JavaDoc will be made non-clickable)
+          {
+            printf '%s\n' '<!DOCTYPE html>'
+            printf '%s\n' '<meta charset="utf-8">'
+            printf '%s\n' '<title>NGAFID JavaDoc</title>'
+            printf '%s\n' '<style>'
+            printf '%s\n' '.missing { text-decoration: line-through; opacity: .6; cursor: not-allowed; }'
+            printf '%s\n' 'body { font: 16px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; padding: 24px; }'
+            printf '%s\n' 'h1 { margin: 0 0 12px; }'
+            printf '%s\n' 'ul { margin: 12px 0 0; padding-left: 20px; }'
+            printf '%s\n' 'small { opacity: .7; }'
+            printf '%s\n' '</style>'
+            printf '%s\n' '<h1>NGAFID JavaDoc</h1>'
+            printf '%s\n' '<ul>'
+            printf '%s\n' "${index_items[@]}"
+            printf '%s\n' '</ul>'
+          } > "$PUBDIR/index.html"
 
           # Explicit check for the generated HTML file
-          test -f "$PUBDIR/index.html"
+          test -f "$PUBDIR/index.html" || { echo "ERROR: $PUBDIR/index.html was not created"; exit 1; }
 
           # Verify the staged JavaDoc files
           echo "Staged HTML count: $(find "$PUBDIR" -name "*.html" | wc -l)"

--- a/.github/workflows/javadoc-test.yml
+++ b/.github/workflows/javadoc-test.yml
@@ -49,9 +49,9 @@ jobs:
 
           # Check what was actually generated
           echo "Checking generated files..."
-          find . -name "*.html" -path "*/target/*" | head -10
+          find . -name "*.html" -path "*/target/*" -print | awk 'NR<=10' || true
           echo "Checking target directories..."
-          find . -name "target" -type d
+          find . -name "target" -type d || true
           echo "Checking if apidocs directory exists..."
           ls -la target/site/ 2>/dev/null || echo "target/site/ not found"
           ls -la target/site/apidocs/ 2>/dev/null || echo "target/site/apidocs/ not found"
@@ -66,12 +66,7 @@ jobs:
             fi
           done
 
-          # Check if any JavaDoc was generated at all
-          echo "Checking for any JavaDoc files..."
-          find . -name "*.html" | grep -i javadoc || echo "No JavaDoc HTML files found"
-          find . -name "*.html" | head -5 || echo "No HTML files found at all"
-
-          # Create index for browsing the different modules
+          # Create landing page index file for browsing the different modules
           cat > "$PUBDIR/index.html" << 'HTML'
           <!DOCTYPE html>
           <meta charset="utf-8">
@@ -87,7 +82,11 @@ jobs:
           HTML
 
           # Explicit check for the generated HTML file
-          test -f target/site/javadoc/index.html
+          test -f "$PUBDIR/index.html"
+
+          # Verify the staged JavaDoc files
+          echo "Staged HTML count: $(find "$PUBDIR" -name "*.html" | wc -l)"
+          find "$PUBDIR" -name "*.html" -print | awk 'NR<=5' || true
 
           echo "Ready for merge to main branch for production deployment"
 

--- a/ngafid-airsync/pom.xml
+++ b/ngafid-airsync/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.ngafid.airsync</groupId>
 
     <properties>
-        <jvm.target>21</jvm.target>
+        <!-- Inherit jvm.target from parent -->
     </properties>
 
     <dependencies>
@@ -36,38 +36,19 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
-
                 <configuration>
-                    <jvmTarget>${jvm.target}</jvmTarget>
                     <sourceDirs>
                         <sourceDir>${project.basedir}/src/main/java</sourceDir>
                         <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
                     </sourceDirs>
                 </configuration>
-
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
-                    <release>21</release>
+                    <release>${jvm.target}</release>
                 </configuration>
             </plugin>
 

--- a/ngafid-core/src/main/java/org/ngafid/core/Config.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/Config.java
@@ -62,3 +62,4 @@ public class Config {
         return value;
     }
 }
+// Trigger workflow

--- a/ngafid-core/src/main/java/org/ngafid/core/Config.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/Config.java
@@ -63,3 +63,4 @@ public class Config {
     }
 }
 // Trigger workflow
+// Test trigger

--- a/ngafid-data-processor/pom.xml
+++ b/ngafid-data-processor/pom.xml
@@ -115,14 +115,25 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <configuration>
-                    <sourceDirs>
-                        <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                    </sourceDirs>
-                </configuration>
                 <executions>
                     <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
                         <configuration>
                             <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
                         </configuration>
@@ -135,6 +146,30 @@
                 <configuration>
                     <release>${jvm.target}</release>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/ngafid-data-processor/pom.xml
+++ b/ngafid-data-processor/pom.xml
@@ -16,7 +16,7 @@
     <name>ngafid-data-processor</name>
 
     <properties>
-        <jvm.target>21</jvm.target>
+        <!-- Inherit jvm.target from parent -->
     </properties>
 
     <dependencies>
@@ -115,28 +115,16 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
+                <configuration>
+                    <sourceDirs>
+                        <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                    </sourceDirs>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>test-compile</id>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
                         <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
-                            </sourceDirs>
+                            <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
                         </configuration>
                     </execution>
                 </executions>
@@ -144,9 +132,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
                 <configuration>
-                    <release>21</release>
+                    <release>${jvm.target}</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/ngafid-www/pom.xml
+++ b/ngafid-www/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <javalin.version>6.6.0</javalin.version>
         <javalin.openapi.version>6.5.0</javalin.openapi.version>
-        <jvm.target>21</jvm.target>
     </properties>
 
     <dependencies>
@@ -98,30 +97,18 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
+                <configuration>
+                    <sourceDirs>
+                        <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                    </sourceDirs>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                            </sourceDirs>
-                            <jvmTarget>${jvm.target}</jvmTarget>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>test-compile</id>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
                         <configuration>
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
                             </sourceDirs>
-                            <jvmTarget>${jvm.target}</jvmTarget>
                         </configuration>
                     </execution>
                 </executions>
@@ -130,7 +117,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
                 <configuration>
                     <release>${jvm.target}</release>
                 </configuration>

--- a/ngafid-www/pom.xml
+++ b/ngafid-www/pom.xml
@@ -97,14 +97,25 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <configuration>
-                    <sourceDirs>
-                        <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                    </sourceDirs>
-                </configuration>
                 <executions>
                     <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
                         <configuration>
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
@@ -120,6 +131,30 @@
                 <configuration>
                     <release>${jvm.target}</release>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Assembly -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <kotlin.version>2.1.20</kotlin.version>
+        <kotlin.version>1.9.20</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <jvm.target>21</jvm.target>

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <source>21</source>
+                    <doclint>none</doclint>
+                    <failOnError>false</failOnError>
+                    <additionalJOption>--enable-preview</additionalJOption>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -153,56 +153,84 @@
     </dependencies>
 
     <build>
-        <plugins>
+        <pluginManagement>
+            <plugins>
+                <!-- Kotlin compiler configuration for all modules -->
+                <plugin>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-maven-plugin</artifactId>
+                    <version>${kotlin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <jvmTarget>${jvm.target}</jvmTarget>
+                        <args>
+                            <arg>-Xjvm-default=all</arg>
+                        </args>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>compile</id>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>test-compile</id>
+                            <goals>
+                                <goal>test-compile</goal>
+                            </goals>
+                            <configuration>
+                                <sourceDirs>
+                                    <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                    <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                                </sourceDirs>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
 
+                <!-- Java compiler configuration for all modules -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <configuration>
+                        <source>21</source>
+                        <target>${jvm.target}</target>
+                        <compilerArgs>
+                            <arg>-Xlint:all</arg>
+                            <arg>-Xmaxwarns</arg>
+                            <arg>50000</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+
+                <!-- JavaDoc configuration for all modules -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.6.3</version>
+                    <configuration>
+                        <source>21</source>
+                        <doclint>none</doclint>
+                        <failOnError>false</failOnError>
+                        <additionalJOption>--enable-preview</additionalJOption>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
             <!-- Kotlin compiler should be listed first! -->
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
-                <extensions>true</extensions>
-
-                <configuration>
-                    <jvmTarget>${jvm.target}</jvmTarget>
-                    <args>
-                        <arg>-Xjvm-default=all</arg>
-                    </args>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
-                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>${jvm.target}</target>
-                    <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                        <arg>-Xmaxwarns</arg>
-                        <arg>50000</arg>
-                    </compilerArgs>
                     <!--                        Exclude everything under org.ngafid.routes.spark-->
                     <excludes>
                         <exclude>org/ngafid/routes/spark/**</exclude>
@@ -240,13 +268,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.6.3</version>
-                <configuration>
-                    <source>21</source>
-                    <doclint>none</doclint>
-                    <failOnError>false</failOnError>
-                    <additionalJOption>--enable-preview</additionalJOption>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,6 @@
                         <source>21</source>
                         <doclint>none</doclint>
                         <failOnError>false</failOnError>
-                        <additionalJOption>--enable-preview</additionalJOption>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <kotlin.version>1.9.22</kotlin.version>
+        <kotlin.version>2.0.21</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <jvm.target>21</jvm.target>
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.19.0</version>
+            <version>2.17.0</version>
         </dependency>
 
         <!-- Testing Dependencies -->
@@ -167,15 +167,6 @@
                     <args>
                         <arg>-Xjvm-default=all</arg>
                     </args>
-                    <jvmArgs>
-                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</jvmArg>
-                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</jvmArg>
-                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</jvmArg>
-                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</jvmArg>
-                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</jvmArg>
-                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</jvmArg>
-                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</jvmArg>
-                    </jvmArgs>
                 </configuration>
 
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <kotlin.version>1.9.20</kotlin.version>
+        <kotlin.version>1.9.22</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <jvm.target>21</jvm.target>
@@ -164,6 +164,18 @@
 
                 <configuration>
                     <jvmTarget>${jvm.target}</jvmTarget>
+                    <args>
+                        <arg>-Xjvm-default=all</arg>
+                    </args>
+                    <jvmArgs>
+                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</jvmArg>
+                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</jvmArg>
+                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</jvmArg>
+                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</jvmArg>
+                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</jvmArg>
+                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</jvmArg>
+                        <jvmArg>--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</jvmArg>
+                    </jvmArgs>
                 </configuration>
 
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -214,8 +214,25 @@
                         <source>21</source>
                         <doclint>none</doclint>
                         <failOnError>false</failOnError>
+
+                        <!-- Ensure both Java and Kotlin outputs are on the classpath -->
+                        <additionalOptions>
+                            <additionalOption>-Xdoclint:none</additionalOption>
+                            <additionalOption>--ignore-source-errors</additionalOption>
+                            <additionalOption>-classpath</additionalOption>
+                            <additionalOption>
+                                ${project.build.outputDirectory}
+                            </additionalOption>
+                        </additionalOptions>
+
+                        <!-- Add Kotlin sources to sourcepath for package discovery (Won't actually be parsed) -->
+                        <sourcepath>
+                            ${project.build.sourceDirectory}:${project.basedir}/src/main/kotlin
+                        </sourcepath>
+
                     </configuration>
                 </plugin>
+
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
This PR adds automatic JavaDoc documentation generation and publishing to GitHub Pages using GitHub Actions. 

When code is pushed to the main branch, the system will:
1. Generate  JavaDoc for all Java and Kotlin source files
2. Create HTML documentation with navigation, search, and cross-references
3. Deploy to GitHub Pages making the documentation publicly accessible
4. Update  on every push to main