### PR TITLE
Docker Compose Properties File Classpath Fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,6 @@ services:
     build:
       context: .
       dockerfile: ngafid-www/Dockerfile
-    command: ["java", "-cp", "/opt/ngafid-core/ngafid-core.jar:/app", "org.ngafid.www.NgafidWebServer"]
     ports:
       - "8181:8181"
     <<: *ngafid-service-common


### PR DESCRIPTION
Adds Docker app folder to classpath to fix potential issues with kafka container not being able to find the ngafid.properties file which Andrew has been having issues with during setup