### PR TITLE
Fix Flights page: prevent double map init, fix empty error modal

### DIFF
--- a/ngafid-frontend/src/error_modal.js
+++ b/ngafid-frontend/src/error_modal.js
@@ -23,19 +23,20 @@ class ErrorModal extends React.Component {
     }
 
     show(title, message) {
+        const t = title != null ? String(title) : "";
+        const m = message != null ? String(message) : "";
         this.setState(
-            {
-                title: String(title),
-                message: String(message),
-            },
-            () => this.bsModal.show()      //<-- Show the modal after state has updated
+            { title: t, message: m },
+            () => {
+                // Don't open modal when both title and message are empty (avoids empty error popup)
+                if (t.trim() || m.trim())
+                    this.bsModal.show();
+            }
         );
     }
 
     render() {
         const { title, message } = this.state;
-
-        console.warn(`Rendering Error Modal with error title: '${title}' and message: '${message}'`);
 
         return (
             <div className='modal-content'>
@@ -82,13 +83,9 @@ root.render(<ErrorModal ref={errorModalRef}/>);
 
 
 export function showErrorModal(title, message) {
-
-    //Got the error modal reference, show it
-    if (errorModalRef.current)
-        errorModalRef.current.show(title, message);
-
-    //Otherwise, log an error
-    else
+    if (!errorModalRef.current) {
         console.error("Error Modal reference is not set. Cannot show error modal.");
-
+        return;
+    }
+    errorModalRef.current.show(title, message);
 }

--- a/ngafid-frontend/src/flights.js
+++ b/ngafid-frontend/src/flights.js
@@ -1035,10 +1035,10 @@ class FlightsPage extends React.Component {
 
                 }
 
-                //Response is invalid, show error modal
-                if (response.errorTitle) {
+                //Response is invalid, show error modal (only if we have something to show)
+                if (response.errorTitle || response.errorMessage) {
                     console.log("Error in 'Get Flights', displaying error modal!");
-                    showErrorModal(response.errorTitle, response.errorMessage);
+                    showErrorModal(response.errorTitle || "Error", response.errorMessage || "");
                     return;
                 }
 

--- a/ngafid-frontend/src/map.js
+++ b/ngafid-frontend/src/map.js
@@ -13,16 +13,20 @@ let styles = [];
 let layers = [];
 
 function initializeMap() {
-
-    // Map already initialized, exit
-    if (map) {
+    // Avoid creating a second map (e.g. DOMContentLoaded and FlightsPage componentDidMount both call this)
+    if (map !== null) {
         console.warn("Map instance already exists, initialization aborted.");
         return;
     }
-    
+
     // Azure Maps key is now injected from backend via template
     if (typeof azureMapsKey === 'undefined' || !azureMapsKey) {
         console.error("Azure Maps key is missing or undefined!");
+        return;
+    }
+
+    // Target element may not exist yet when DOMContentLoaded runs before React has rendered (e.g. Flights page)
+    if (!document.getElementById('map')) {
         return;
     }
 
@@ -156,9 +160,11 @@ function createBaseMapLayers(azureKey) {
     return { styles, layers };
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  initializeMap();
-});
+// Do not auto-initialize on DOMContentLoaded: on the Flights page the #map div is inside
+// React and may be hidden when DOMContentLoaded fires, so that init would create a
+// zero-size map and cause componentDidMount to abort the correct init. Let the
+// page (Flights, TTF, etc.) call initializeMap() from componentDidMount only.
+// document.addEventListener('DOMContentLoaded', () => { initializeMap(); });
 
 const container = document.getElementById('popup');
 const content = document.getElementById('popup-content');


### PR DESCRIPTION
Problem

Map and flights did not show on the Flights page (/protected/flights).
Console showed "Map instance already exists, initialization aborted" and an error modal with empty title/message.


Map was initialized twice (DOMContentLoaded and FlightsPage componentDidMount). The first init ran while the map container was hidden, so the map had zero size and the correct init was skipped.
Error modal could be shown with empty title/message from the API.


Changes

map.js: Guard against double initializeMap(); require #map in DOM; remove DOMContentLoaded auto-init so only the page's componentDidMount initializes the map.
error_modal.js: Only open the modal when title or message is non-empty; remove noisy render log; safe handling of null/undefined.
flights.js: Use fallbacks when showing API errors (response.errorTitle || "Error", response.errorMessage || "").

