### PR TITLE
Allow creation of new Fleets without needing a new account

### DIFF
--- a/ngafid-core/src/main/java/org/ngafid/core/accounts/User.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/accounts/User.java
@@ -86,9 +86,7 @@ public final class User implements Serializable {
         this.aggregateView = aggregateView;
         this.passwordToken = "";
 
-        this.fleet = Fleet.get(connection, fleetId);
-        this.fleetAccess = FleetAccess.get(connection, id, fleetId);
-        this.fleetSelected = fleetSelected;
+        setSelectedFleetId(connection, fleetSelected);
 
         LOG.log(
                 Level.INFO,
@@ -1221,6 +1219,9 @@ public final class User implements Serializable {
 
         // give use manager access of this fleet
         user.fleetAccess = FleetAccess.create(connection, user.getId(), user.fleet.getId(), FleetAccess.MANAGER);
+
+        // set the user's selected fleet to this new fleet
+        user.setSelectedFleetId(connection, user.fleet.getId());
 
         return user;
     }

--- a/ngafid-frontend/src/multifleet/multifleet_select.tsx
+++ b/ngafid-frontend/src/multifleet/multifleet_select.tsx
@@ -2,12 +2,13 @@
 import React from "react";
 
 import { showErrorModal } from "../error_modal";
+import { showAjaxErrorModal } from "../extract_ajax_error_message";
 import type { accessType, MultifleetSelectWithAccess } from "../types";
-
-
-
-import '../index.css';          //<-- include Tailwind
 import { showConfirmModal } from "../confirm_modal";
+import '../index.css'; //<-- include Tailwind
+import { InfoHint } from "../info_hint";
+
+const FLEET_NAME_LENGTH_LIMIT = 256;
 
 
 function leaveSelectedFleet() {
@@ -22,8 +23,8 @@ function leaveSelectedFleet() {
             window.location.reload();
         },
         error: (jqXHR, textStatus, errorThrown) => {
+            showAjaxErrorModal(jqXHR, errorThrown, "Error Leaving Selected Fleet");
             console.error("Error leaving the selected fleet:", errorThrown);
-            showErrorModal("Error Leaving Selected Fleet", errorThrown);
         }
     });
 
@@ -116,6 +117,41 @@ type MultifleetSelectProps = {
 export function MultifleetSelect({ fleetsWithAccess, fleetSelected, updateSelectedFleet }: MultifleetSelectProps) {
 
     console.log("Rendering MultifleetSelect with fleets:", fleetsWithAccess);
+    const [newFleetName, setNewFleetName] = React.useState("");
+    const [isCreatingFleet, setIsCreatingFleet] = React.useState(false);
+
+    const trimmedFleetName = newFleetName.trim();
+    const fleetNameRegex = /^[a-zA-Z0-9 @#$%^&*()_+!.,/\\]+$/;
+    const isFleetNameValid =
+        (trimmedFleetName.length > 0)
+        && (trimmedFleetName.length < FLEET_NAME_LENGTH_LIMIT)
+        && fleetNameRegex.test(trimmedFleetName);
+
+    const createFleet = () => {
+
+        // Prevent multiple submissions or invalid fleet names
+        if (isCreatingFleet || !isFleetNameValid)
+            return;
+
+        setIsCreatingFleet(true);
+
+        $.ajax({
+            type: 'POST',
+            url: '/api/user/create-fleet',
+            async: true,
+            data: { fleetName: trimmedFleetName },
+            success: (response) => {
+                console.log("Successfully created and selected new fleet:", response);
+                window.location.reload();
+            },
+            error: (jqXHR, textStatus, errorThrown) => {
+                showAjaxErrorModal(jqXHR, errorThrown, "Error Creating Fleet");
+                console.error("Error creating new fleet:", errorThrown);
+                setIsCreatingFleet(false);
+            }
+        });
+    };
+
     const fleetsWithAccessCount = fleetsWithAccess.length;
 
     //No fleets to select from, something is wrong
@@ -125,9 +161,6 @@ export function MultifleetSelect({ fleetsWithAccess, fleetSelected, updateSelect
         return null;
     }
 
-    //No (other) fleets to select from, show nothing
-    if (fleetsWithAccessCount === 1)
-        return null;
 
     //Check if the user is a manager of the selected fleet
     const selectedFleetAccess = fleetsWithAccess.find(fleet => fleet.fleetId === fleetSelected);
@@ -185,6 +218,52 @@ export function MultifleetSelect({ fleetsWithAccess, fleetSelected, updateSelect
                                     updateSelectedFleet={updateSelectedFleet}
                                 />
                             ))}
+                        </div>
+                    </div>
+
+                    {/* Card Footer Area */}
+                    <div className="card-footer">
+                        <div className="flex flex-col gap-2">
+
+                            {/* Mass-Toggle Instruction */}
+                            <InfoHint message={"Created fleets cannot be deleted. Fleets cannot be left unless another valid fleet is available, and another user can manage it."} />
+
+                            <label className="mb-1 font-weight-bold" htmlFor="new-fleet-name-input">
+                                Create New Fleet
+                            </label>
+
+                            <div className="flex gap-2 items-center w-full">
+
+                                {/* Fleet Name Input */}
+                                <input
+                                    id="new-fleet-name-input"
+                                    className="form-control"
+                                    type="text"
+                                    placeholder="Enter fleet name"
+                                    value={newFleetName}
+                                    maxLength={FLEET_NAME_LENGTH_LIMIT}
+                                    onChange={(event) => setNewFleetName(event.target.value)}
+                                />
+
+                                {/* Create Button */}
+                                <button
+                                    className={`btn btn-success ${(!isFleetNameValid || isCreatingFleet) ? 'button-disabled' : ''}`}
+                                    disabled={!isFleetNameValid || isCreatingFleet}
+                                    onClick={createFleet}
+                                >
+                                    <i className="fa fa-plus mr-2" />
+                                    {isCreatingFleet ? "Creating..." : "Create Fleet"}
+                                </button>
+                            </div>
+
+                            {/* Bad Fleet Name Warning */}
+                            {
+                                (trimmedFleetName.length > 0 && !isFleetNameValid)
+                                &&
+                                <small className="text-danger d-block mt-1">
+                                    Fleet name must be 1-{FLEET_NAME_LENGTH_LIMIT} characters and may only include letters, numbers, spaces, and @#$%^&*()_+!/\\.,
+                                </small>
+                            }
                         </div>
                     </div>
                 </div>

--- a/ngafid-frontend/tsconfig.json
+++ b/ngafid-frontend/tsconfig.json
@@ -5,6 +5,7 @@
         "jsx": "react-jsx",
 
         "strict": true,
+        "ignoreDeprecations": "6.0",
         "moduleResolution": "node",
         "resolveJsonModule": true,
         "isolatedModules": true,

--- a/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/UserRoutes.kt
+++ b/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/UserRoutes.kt
@@ -8,6 +8,7 @@ import io.javalin.http.pathParamAsClass
 import io.javalin.openapi.*
 import org.ngafid.core.Database
 import org.ngafid.core.accounts.EmailType
+import org.ngafid.core.accounts.AccountException
 import org.ngafid.core.accounts.Fleet
 import org.ngafid.core.accounts.FleetAccess
 import org.ngafid.core.accounts.FleetAccessNamed
@@ -59,6 +60,7 @@ object UserRoutes : RouteProvider() {
                 }
 
                 get("fleet-access", UserRoutes::getUserFullFleetAccess, Role.LOGGED_IN)
+                post("create-fleet", UserRoutes::postUserCreateFleet, Role.LOGGED_IN)
                 put("select-fleet", UserRoutes::putUserFleetSelected, Role.LOGGED_IN)
                 put("leave-fleet", UserRoutes::putUserLeaveCurrentFleet, Role.LOGGED_IN)
 
@@ -71,6 +73,64 @@ object UserRoutes : RouteProvider() {
 
             }
         }
+    }
+
+    fun postUserCreateFleet(ctx: Context) {
+
+        val user = SessionUtility.getUser(ctx)
+        val fleetName = ctx.formParam("fleetName")?.trim()
+
+        // Fleet name cannot be empty or null
+        if (fleetName.isNullOrEmpty()) {
+            ctx.status(400)
+            ctx.json(ErrorResponse("Invalid Fleet Name", "Fleet name cannot be empty."))
+            return
+        }
+
+        val FLEET_NAME_LENGTH_LIMIT = 256
+
+        val validFleetNameRegex = Regex("^[\\@\\#\\$\\%\\^\\&\\*\\(\\)\\_\\+\\!\\/\\\\\\.\\,a-zA-Z0-9 ]+$")
+        if (fleetName.length >= FLEET_NAME_LENGTH_LIMIT || !validFleetNameRegex.matches(fleetName)) {
+            ctx.status(400)
+            ctx.json(
+                ErrorResponse(
+                    "Invalid Fleet Name",
+                    "Fleet name must be 1-${FLEET_NAME_LENGTH_LIMIT} characters and may only include letters, numbers, spaces, and @#$%^&*()_+!/\\.,"
+                )
+            )
+            return
+        }
+
+        Database.getConnection().use { connection ->
+            val previousAutoCommit = connection.autoCommit
+
+            try {
+                connection.autoCommit = false
+
+                // Create the fleet
+                val fleet = Fleet.create(connection, fleetName)
+                FleetAccess.create(connection, user.id, fleet.id, FleetAccess.MANAGER)
+
+                // Set the user's selected fleet to the newly created fleet
+                user.setSelectedFleetId(connection, fleet.id)
+
+                connection.commit()
+                ctx.status(201)
+                ctx.json(fleet)
+            } catch (e: AccountException) {
+                connection.rollback()
+                ctx.status(400)
+                ctx.json(ErrorResponse(e))
+            } catch (e: SQLException) {
+                connection.rollback()
+                LOG.severe("Error creating fleet '${fleetName}' for user ${user.id}: ${e.message}")
+                ctx.status(500)
+                ctx.json(ErrorResponse("Fleet Creation Error", e.message ?: "Unknown database error."))
+            } finally {
+                connection.autoCommit = previousAutoCommit
+            }
+        }
+        
     }
 
     fun putUserFleetSelected(ctx: Context) {
@@ -115,7 +175,7 @@ object UserRoutes : RouteProvider() {
         } catch (e: SQLException) {
             LOG.severe("Error when user ${user.getId()} attempted to leave fleet ${user.getFleetId()}: ${e.message}")
             ctx.status(500)
-            ctx.result("Error when attempting to leave fleet.")
+            ctx.result("Error when attempting to leave fleet: ${e.message}")
             return
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,10 @@
     </modules>
 
     <properties>
-        <kotlin.version>2.3.10</kotlin.version>
+        <kotlin.version>2.3.20</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
+        <kotlin.compiler.jdkHome>${env.JAVA_HOME}</kotlin.compiler.jdkHome>
         <jvm.target>24</jvm.target>
         <maven.compiler.release>24</maven.compiler.release>
         <jacoco.skip>false</jacoco.skip>
@@ -31,6 +32,18 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
         <!-- Logging library -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -164,6 +177,7 @@
                     <version>${kotlin.version}</version>
                     <configuration>
                         <jvmTarget>${jvm.target}</jvmTarget>
+                        <jdkHome>${kotlin.compiler.jdkHome}</jdkHome>
                         <args>
                             <arg>-Xjvm-default=all</arg>
                         </args>


### PR DESCRIPTION
* pom.xml: Bumped Kotlin version from 2.3.10 to 2.3.20

---

* Preferences Page: Users can now create new fleets with a given name
  * Will automatically switch the user to this fleet after creation
  * Users will be a manager of this fleet
* Fixed an issue with new accounts where their selected fleet was not being properly set

<img width="3780" height="569" alt="image" src="https://github.com/user-attachments/assets/5bf6d244-3f22-4619-875a-1bc35a7d46d6" />
<img width="3767" height="609" alt="image" src="https://github.com/user-attachments/assets/08b19c32-1e84-4a03-ac73-c86773288677" />
