### PR TITLE
Kafka: spread upload messages across partitions 

### DIFF
--- a/ngafid-core/src/main/java/org/ngafid/core/bin/UploadHelper.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/bin/UploadHelper.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
+import org.ngafid.core.kafka.Topic;
+
 import static org.ngafid.core.kafka.Configuration.getUploadProperties;
 
 public class UploadHelper {
@@ -121,7 +123,8 @@ public class UploadHelper {
 
     private static void enqueueUploads(List<Integer> uploadIds) {
         try (KafkaProducer<String, Integer> producer = getUploadProducer()) {
-            for (Integer uploadId : uploadIds) producer.send(new ProducerRecord<>("upload", uploadId));
+            for (Integer uploadId : uploadIds)
+                producer.send(new ProducerRecord<>(Topic.UPLOAD.toString(), String.valueOf(uploadId), uploadId));
         }
     }
 
@@ -142,7 +145,8 @@ public class UploadHelper {
                             while (resultSet.next()) {
                                 int uploadId = resultSet.getInt(1);
                                 LOG.info("Added upload id = " + uploadId + " to `upload` topic.");
-                                producer.send(new ProducerRecord<>("upload", uploadId));
+                                producer.send(
+                                        new ProducerRecord<>(Topic.UPLOAD.toString(), String.valueOf(uploadId), uploadId));
                                 idCursor = Math.max(uploadId, idCursor);
                                 nRows += 1;
                             }

--- a/ngafid-core/src/main/java/org/ngafid/core/kafka/DisjointConsumer.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/kafka/DisjointConsumer.java
@@ -75,10 +75,10 @@ public abstract class DisjointConsumer<K, V> implements AutoCloseable {
             if (retry) {
                 if (record.topic().equals(getTopicName())) {
                     LOG.info("Processing failed... adding to retry queue '" + getRetryTopicName() + "'");
-                    producer.send(new ProducerRecord<>(getRetryTopicName(), record.value()));
+                    producer.send(new ProducerRecord<>(getRetryTopicName(), record.key(), record.value()));
                 } else if (record.topic().equals(getRetryTopicName())) {
                     LOG.info("Processing failed... adding to DLQ '" + getDLTTopicName() + "'");
-                    producer.send(new ProducerRecord<>(getDLTTopicName(), record.value()));
+                    producer.send(new ProducerRecord<>(getDLTTopicName(), record.key(), record.value()));
                 }
             }
         }

--- a/ngafid-core/src/main/java/org/ngafid/core/uploads/Upload.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/uploads/Upload.java
@@ -149,7 +149,9 @@ public final class Upload {
                 if (producer == null)
                     producer = new KafkaProducer<>(Configuration.getUploadProperties());
 
-                producer.send(new ProducerRecord<>(Topic.UPLOAD.toString(), id));
+                // Key upload id so the default partitioner spreads messages across topic partitions
+                // (null-key produces can skew onto one partition and under-use parallel consumers).
+                producer.send(new ProducerRecord<>(Topic.UPLOAD.toString(), String.valueOf(id), id));
                 producer.flush();
                 producer.close();
                 producer = null;


### PR DESCRIPTION
We were producing  records without a key, so the default partitioner put most traffic on one partition. With multiple UploadConsumer instances, only the consumer owning that “hot” partition stayed busy; the others sat idle even though the topic has six partitions.

Changes:

Upload.java — When enqueueing a completed upload, send ProducerRecord with String.valueOf(id) as the key and the upload id as the value so records hash across partitions and parallel consumers can drain work evenly.
UploadHelper.java — Same keyed produce for manual requeues; use Topic.UPLOAD instead of a raw "upload" string for consistency.
DisjointConsumer.java — When forwarding failures to retry / DLQ, pass record.key() through so keys are not dropped on the retry path (keeps partitioning behavior consistent).

Testing:
All 6 consumers have work to do: 97, 73, 81, 76, 93, 79 messages 

```

ngafid          upload-retry    3          -               0               -               consumer-ngafid-1-6e6296b3-89c8-4697-bdc8-a711410836d3 /172.18.0.5     consumer-ngafid-1
ngafid          upload          3          2               97              95              consumer-ngafid-1-6e6296b3-89c8-4697-bdc8-a711410836d3 /172.18.0.5     consumer-ngafid-1
ngafid          upload-retry    4          -               0               -               consumer-ngafid-1-8d3949cd-e126-4f3b-9e90-5ecd0753d864 /172.18.0.10    consumer-ngafid-1
ngafid          upload          4          2               73              71              consumer-ngafid-1-8d3949cd-e126-4f3b-9e90-5ecd0753d864 /172.18.0.10    consumer-ngafid-1
ngafid          upload-retry    1          -               0               -               consumer-ngafid-1-63fcaf29-4d8c-46b7-9e95-07af3a9d1c45 /172.18.0.12    consumer-ngafid-1
ngafid          upload          1          -               81              -               consumer-ngafid-1-63fcaf29-4d8c-46b7-9e95-07af3a9d1c45 /172.18.0.12    consumer-ngafid-1
ngafid          upload-retry    2          -               0               -               consumer-ngafid-1-670f0519-f99b-45a4-a676-719b6a1c0e20 /172.18.0.8     consumer-ngafid-1
ngafid          upload          2          -               76              -               consumer-ngafid-1-670f0519-f99b-45a4-a676-719b6a1c0e20 /172.18.0.8     consumer-ngafid-1
ngafid          upload-retry    0          -               0               -               consumer-ngafid-1-001c732c-7055-46d2-b735-232a07d2720b /172.18.0.9     consumer-ngafid-1
ngafid          upload          0          -               93              -               consumer-ngafid-1-001c732c-7055-46d2-b735-232a07d2720b /172.18.0.9     consumer-ngafid-1
ngafid          upload-retry    5          -               0               -               consumer-ngafid-1-d1c31ed5-c587-484e-8ecd-bd8c963a775f /172.18.0.11    consumer-ngafid-1
ngafid          upload          5          -               79              -               consumer-ngafid-1-d1c31ed5-c587-484e-8ecd-bd8c963a775f /172.18.0.11    consumer-ngafid-1
```



Before we had only one consumer getting work - see consumer 1 - has     648      messages while other consumers are idle.
```

ngafid          upload-retry    0          -               0               -               consumer-ngafid-1-47b70107-43b7-463a-8ec2-0757d7d6f853 /172.18.0.5     consumer-ngafid-1
ngafid          upload          0          151             648             497             consumer-ngafid-1-47b70107-43b7-463a-8ec2-**0757d7d6f853 /172.18.0.5     consumer-ngafid-1
ngafid          upload-retry    2          -               0               -               consumer-ngafid-1-81c36578-98e3-4001-8f0d-ce716372b505 /172.18.0.8     consumer-ngafid-1
ngafid          upload          2          -               0               -               consumer-ngafid-1-81c36578-98e3-4001-8f0d-ce716372b505 /172.18.0.8     consumer-ngafid-1
ngafid          upload-retry    3          -               1               -               consumer-ngafid-1-d5cf5bda-013d-4a18-9b5a-c0c17147334d /172.18.0.12    consumer-ngafid-1
ngafid          upload          3          5               8               3               consumer-ngafid-1-d5cf5bda-013d-4a18-9b5a-c0c17147334d /172.18.0.12    consumer-ngafid-1
ngafid          upload-retry    5          -               0               -               consumer-ngafid-1-e8d35d98-24bf-44c2-8145-0451d7cc6872 /172.18.0.11    consumer-ngafid-1
ngafid          upload          5          2               2               0               consumer-ngafid-1-e8d35d98-24bf-44c2-8145-0451d7cc6872 /172.18.0.11    consumer-ngafid-1
ngafid          upload-retry    1          -               0               -               consumer-ngafid-1-713bb96b-58ef-4069-be61-0f86f5993d96 /172.18.0.10    consumer-ngafid-1
ngafid          upload          1          5               5               0               consumer-ngafid-1-713bb96b-58ef-4069-be61-0f86f5993d96 /172.18.0.10    consumer-ngafid-1
ngafid          upload-retry    4          -               0               -               consumer-ngafid-1-df8b9db5-04ae-4d60-8f4c-9de160c6ed3f /172.18.0.9     consumer-ngafid-1
ngafid          upload          4          -               0               -               consumer-ngafid-1-df8b9db5-04ae-4d60-8f4c-9de160c6ed3f /172.18.0.9     consumer-ngafid-1
```