### PR TITLE
fix monthly event trends

### DIFF
--- a/ngafid-frontend/src/trends.tsx
+++ b/ngafid-frontend/src/trends.tsx
@@ -192,7 +192,8 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
                     const responseObj = response as { [eventName: string]: { [airframeName: string]: TrendsData } };
 
                     const countsMerged: { [airframeName: string]: TrendsData } = {};
-                    for (const countsObject of Object.values(responseObj)) {
+                    const eventCountEntries = Object.entries(responseObj).filter(([eventName]) => eventName !== "ANY Event");
+                    for (const [, countsObject] of eventCountEntries) {
 
                         for (const airframeName of Object.keys(countsObject)) {
 
@@ -226,10 +227,16 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
 
                                     countsMerged[airframeName].aggregateFlightsWithEventCounts[i] += countsAirframe.aggregateFlightsWithEventCounts[i];
                                     countsMerged[airframeName].aggregateTotalEventsCounts[i] += countsAirframe.aggregateTotalEventsCounts[i];
-                                    countsMerged[airframeName].aggregateTotalFlightsCounts[i] += countsAirframe.aggregateTotalFlightsCounts[i];
+                                    countsMerged[airframeName].aggregateTotalFlightsCounts[i] = Math.max(
+                                        countsMerged[airframeName].aggregateTotalFlightsCounts[i],
+                                        countsAirframe.aggregateTotalFlightsCounts[i]
+                                    );
                                     countsMerged[airframeName].flightsWithEventCounts[i] += countsAirframe.flightsWithEventCounts[i];
                                     countsMerged[airframeName].totalEventsCounts[i] += countsAirframe.totalEventsCounts[i];
-                                    countsMerged[airframeName].totalFlightsCounts[i] += countsAirframe.totalFlightsCounts[i];
+                                    countsMerged[airframeName].totalFlightsCounts[i] = Math.max(
+                                        countsMerged[airframeName].totalFlightsCounts[i],
+                                        countsAirframe.totalFlightsCounts[i]
+                                    );
                                 }
 
                             }
@@ -240,7 +247,7 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
 
                     setEventCounts({
                         ...responseObj,
-                        ["ANY Event"]: countsMerged
+                        ["ANY Event"]: responseObj["ANY Event"] ?? countsMerged
                     });
 
                     resolve(response);

--- a/ngafid-www/src/main/java/org/ngafid/www/EventStatistics.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/EventStatistics.java
@@ -79,9 +79,9 @@ public class EventStatistics {
             SELECT fleet_id, event_definition_id, airframe_id,
                 SUM(event_count) as event_count, SUM(flight_count) as flight_count
             FROM m_fleet_airframe_monthly_event_counts
-            WHERE """ + dateClause + """
+            WHERE %s
             GROUP BY fleet_id, event_definition_id, airframe_id
-        """;
+        """.formatted(dateClause);
 
         Map<Integer, String> idToAirframeNameMap = Airframes.getIdToNameMap(connection);
         Map<Integer, String> idToEventNameMap = EventDefinition.getEventDefinitionIdToNameMap(connection);
@@ -174,6 +174,21 @@ public class EventStatistics {
     public static Map<String, Map<String, MonthlyEventCounts>> getMonthlyEventCounts(
             Connection connection, int fleetId, LocalDate startDateNullable, LocalDate endDateNullable)
             throws SQLException {
+        Map<Integer, String> idToAirframeNameMap = Airframes.getIdToNameMap(connection);
+        Map<Integer, String> idToEventNameMap = EventDefinition.getEventDefinitionIdToNameMap(connection);
+
+        return getMonthlyEventCounts(
+                connection, fleetId, startDateNullable, endDateNullable, idToAirframeNameMap, idToEventNameMap);
+    }
+
+    static Map<String, Map<String, MonthlyEventCounts>> getMonthlyEventCounts(
+            Connection connection,
+            int fleetId,
+            LocalDate startDateNullable,
+            LocalDate endDateNullable,
+            Map<Integer, String> idToAirframeNameMap,
+            Map<Integer, String> idToEventNameMap)
+            throws SQLException {
         final LocalDate startDate = startDateNullable == null ? LocalDate.of(0, 1, 1) : startDateNullable;
         final LocalDate endDate = endDateNullable == null ? LocalDate.now() : endDateNullable;
 
@@ -186,10 +201,9 @@ public class EventStatistics {
                         + dateClause + " GROUP BY fleet_id, event_definition_id, airframe_id, year, month";
 
         try (PreparedStatement statement = connection.prepareStatement(query)) {
-            Map<Integer, String> idToAirframeNameMap = Airframes.getIdToNameMap(connection);
-            Map<Integer, String> idToEventNameMap = EventDefinition.getEventDefinitionIdToNameMap(connection);
-
-            FlightCounts fc = getFlightCounts(connection, startDate, endDate);
+            Map<MonthlyCountKey, Integer> fleetMonthlyFlightCounts = getFleetMonthlyFlightCounts(connection, dateClause);
+            Map<MonthlyCountKey, Integer> aggregateMonthlyFlightCounts =
+                    getAggregateMonthlyFlightCounts(connection, dateClause);
             Map<String, Map<String, MonthlyEventCountsBuilder>> eventCounts = new HashMap<>();
 
             try (ResultSet result = statement.executeQuery()) {
@@ -201,7 +215,10 @@ public class EventStatistics {
                     final int airframeId = result.getInt("airframe_id");
                     final int month = result.getInt("month");
                     final int year = result.getInt("year");
-                    final int totalFlights = fc.getFleetCounts(fleet).get(airframeId);
+                    final int totalFlights = fleetMonthlyFlightCounts.getOrDefault(
+                            monthlyCountKey(fleet, airframeId, year, month), 0);
+                    final int aggregateTotalFlights = aggregateMonthlyFlightCounts.getOrDefault(
+                            monthlyCountKey(-1, airframeId, year, month), 0);
 
                     final String date = LocalDate.of(year, month, 1).toString();
                     final String eventName = idToEventNameMap.get(eventDefinitionId);
@@ -213,15 +230,239 @@ public class EventStatistics {
                                     airframeName,
                                     k -> new MonthlyEventCountsBuilder(airframeName, eventName, startDate, endDate));
 
-                    mec.updateAggregate(date, flightCount, totalFlights, eventCount);
-                    if (fleetId == fleet) mec.update(date, flightCount, totalFlights, eventCount);
+                    mec.updateAggregateWithTotalFlightsMax(date, flightCount, aggregateTotalFlights, eventCount);
+                    if (fleetId == fleet) mec.updateWithTotalFlightsMax(date, flightCount, totalFlights, eventCount);
                 }
             }
+
+            addAnyEventMonthlyCounts(
+                    connection,
+                    fleetId,
+                    startDate,
+                    endDate,
+                    dateClause,
+                    idToAirframeNameMap,
+                    fleetMonthlyFlightCounts,
+                    aggregateMonthlyFlightCounts,
+                    eventCounts);
+
+            seedMonthlyFlightDenominators(
+                    fleetId,
+                    startDate,
+                    endDate,
+                    idToAirframeNameMap,
+                    fleetMonthlyFlightCounts,
+                    aggregateMonthlyFlightCounts,
+                    eventCounts);
 
             return eventCounts.entrySet().stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().entrySet().stream()
                             .collect(Collectors.toMap(
                                     Map.Entry::getKey, e -> e.getValue().build()))));
+        }
+    }
+
+    private record MonthlyCountKey(int fleetId, int airframeId, int year, int month) {}
+
+    private static MonthlyCountKey monthlyCountKey(int fleetId, int airframeId, int year, int month) {
+        return new MonthlyCountKey(fleetId, airframeId, year, month);
+    }
+
+    private static Map<MonthlyCountKey, Integer> getFleetMonthlyFlightCounts(Connection connection, String dateClause)
+            throws SQLException {
+        String query = """
+            SELECT fleet_id, airframe_id, year, month, SUM(count) AS flight_count
+            FROM m_fleet_monthly_flight_counts
+            WHERE %s
+            GROUP BY fleet_id, airframe_id, year, month
+        """.formatted(dateClause);
+
+        Map<MonthlyCountKey, Integer> counts = new HashMap<>();
+        try (PreparedStatement statement = connection.prepareStatement(query);
+                ResultSet result = statement.executeQuery()) {
+            while (result.next()) {
+                counts.put(
+                        monthlyCountKey(
+                                result.getInt("fleet_id"),
+                                result.getInt("airframe_id"),
+                                result.getInt("year"),
+                                result.getInt("month")),
+                        result.getInt("flight_count"));
+            }
+        }
+        return counts;
+    }
+
+    private static Map<MonthlyCountKey, Integer> getAggregateMonthlyFlightCounts(Connection connection, String dateClause)
+            throws SQLException {
+        String query = """
+            SELECT airframe_id, year, month, SUM(count) AS flight_count
+            FROM m_fleet_monthly_flight_counts
+            WHERE %s
+            GROUP BY airframe_id, year, month
+        """.formatted(dateClause);
+
+        Map<MonthlyCountKey, Integer> counts = new HashMap<>();
+        try (PreparedStatement statement = connection.prepareStatement(query);
+                ResultSet result = statement.executeQuery()) {
+            while (result.next()) {
+                counts.put(
+                        monthlyCountKey(
+                                -1,
+                                result.getInt("airframe_id"),
+                                result.getInt("year"),
+                                result.getInt("month")),
+                        result.getInt("flight_count"));
+            }
+        }
+        return counts;
+    }
+
+    private static void addAnyEventMonthlyCounts(
+            Connection connection,
+            int selectedFleetId,
+            LocalDate startDate,
+            LocalDate endDate,
+            String dateClause,
+            Map<Integer, String> idToAirframeNameMap,
+            Map<MonthlyCountKey, Integer> fleetMonthlyFlightCounts,
+            Map<MonthlyCountKey, Integer> aggregateMonthlyFlightCounts,
+            Map<String, Map<String, MonthlyEventCountsBuilder>> eventCounts)
+            throws SQLException {
+
+        final String anyEventName = "ANY Event";
+        Map<String, MonthlyEventCountsBuilder> anyEventCounts =
+                eventCounts.computeIfAbsent(anyEventName, k -> new HashMap<>());
+
+        if (selectedFleetId >= 0) {
+            String fleetQuery = """
+                SELECT fleet_id, airframe_id, year, month,
+                    COUNT(event_id) AS event_count,
+                    COUNT(DISTINCT flight_id) AS flight_count
+                FROM (
+                    SELECT e.fleet_id, f.airframe_id, YEAR(e.start_time) AS year, MONTH(e.start_time) AS month,
+                        e.id AS event_id, f.id AS flight_id
+                    FROM events e
+                    INNER JOIN flights f ON f.id = e.flight_id
+                    WHERE e.fleet_id = ?
+                ) monthly_events
+                WHERE %s
+                GROUP BY fleet_id, airframe_id, year, month
+            """.formatted(dateClause);
+
+            try (PreparedStatement statement = connection.prepareStatement(fleetQuery)) {
+                statement.setInt(1, selectedFleetId);
+
+                try (ResultSet result = statement.executeQuery()) {
+                    while (result.next()) {
+                        final int fleetId = result.getInt("fleet_id");
+                        final int airframeId = result.getInt("airframe_id");
+                        final int year = result.getInt("year");
+                        final int month = result.getInt("month");
+                        final String airframeName = idToAirframeNameMap.get(airframeId);
+                        if (airframeName == null) continue;
+
+                        final String date = LocalDate.of(year, month, 1).toString();
+                        final int totalFlights = fleetMonthlyFlightCounts.getOrDefault(
+                                monthlyCountKey(fleetId, airframeId, year, month), 0);
+
+                        MonthlyEventCountsBuilder builder = anyEventCounts.computeIfAbsent(
+                                airframeName,
+                                k -> new MonthlyEventCountsBuilder(airframeName, anyEventName, startDate, endDate));
+                        builder.updateWithTotalFlightsMax(
+                                date, result.getInt("flight_count"), totalFlights, result.getInt("event_count"));
+                    }
+                }
+            }
+        }
+
+        String aggregateQuery = """
+            SELECT airframe_id, year, month,
+                COUNT(event_id) AS event_count,
+                COUNT(DISTINCT flight_id) AS flight_count
+            FROM (
+                SELECT f.airframe_id, YEAR(e.start_time) AS year, MONTH(e.start_time) AS month,
+                    e.id AS event_id, f.id AS flight_id
+                FROM events e
+                INNER JOIN flights f ON f.id = e.flight_id
+            ) monthly_events
+            WHERE %s
+            GROUP BY airframe_id, year, month
+        """.formatted(dateClause);
+
+        try (PreparedStatement statement = connection.prepareStatement(aggregateQuery);
+                ResultSet result = statement.executeQuery()) {
+            while (result.next()) {
+                final int airframeId = result.getInt("airframe_id");
+                final int year = result.getInt("year");
+                final int month = result.getInt("month");
+                final String airframeName = idToAirframeNameMap.get(airframeId);
+                if (airframeName == null) continue;
+
+                final String date = LocalDate.of(year, month, 1).toString();
+                final int totalFlights = aggregateMonthlyFlightCounts.getOrDefault(
+                        monthlyCountKey(-1, airframeId, year, month), 0);
+
+                MonthlyEventCountsBuilder builder = anyEventCounts.computeIfAbsent(
+                        airframeName,
+                        k -> new MonthlyEventCountsBuilder(airframeName, anyEventName, startDate, endDate));
+                builder.updateAggregate(
+                        date, result.getInt("flight_count"), totalFlights, result.getInt("event_count"));
+            }
+        }
+    }
+
+    private static void seedMonthlyFlightDenominators(
+            int selectedFleetId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Map<Integer, String> idToAirframeNameMap,
+            Map<MonthlyCountKey, Integer> fleetMonthlyFlightCounts,
+            Map<MonthlyCountKey, Integer> aggregateMonthlyFlightCounts,
+            Map<String, Map<String, MonthlyEventCountsBuilder>> eventCounts) {
+
+        final String anyEventName = "ANY Event";
+        Map<String, MonthlyEventCountsBuilder> anyEventCounts =
+                eventCounts.computeIfAbsent(anyEventName, k -> new HashMap<>());
+
+        for (Map.Entry<MonthlyCountKey, Integer> entry : aggregateMonthlyFlightCounts.entrySet()) {
+            final MonthlyCountKey key = entry.getKey();
+            final String airframeName = idToAirframeNameMap.get(key.airframeId());
+            if (airframeName == null) continue;
+
+            anyEventCounts.computeIfAbsent(
+                    airframeName,
+                    k -> new MonthlyEventCountsBuilder(airframeName, anyEventName, startDate, endDate));
+
+            final String date = LocalDate.of(key.year(), key.month(), 1).toString();
+            for (Map<String, MonthlyEventCountsBuilder> countsByAirframe : eventCounts.values()) {
+                MonthlyEventCountsBuilder builder = countsByAirframe.get(airframeName);
+                if (builder != null) {
+                    builder.updateAggregateWithTotalFlightsMax(date, 0, entry.getValue(), 0);
+                }
+            }
+        }
+
+        if (selectedFleetId < 0) return;
+
+        for (Map.Entry<MonthlyCountKey, Integer> entry : fleetMonthlyFlightCounts.entrySet()) {
+            final MonthlyCountKey key = entry.getKey();
+            if (key.fleetId() != selectedFleetId) continue;
+
+            final String airframeName = idToAirframeNameMap.get(key.airframeId());
+            if (airframeName == null) continue;
+
+            anyEventCounts.computeIfAbsent(
+                    airframeName,
+                    k -> new MonthlyEventCountsBuilder(airframeName, anyEventName, startDate, endDate));
+
+            final String date = LocalDate.of(key.year(), key.month(), 1).toString();
+            for (Map<String, MonthlyEventCountsBuilder> countsByAirframe : eventCounts.values()) {
+                MonthlyEventCountsBuilder builder = countsByAirframe.get(airframeName);
+                if (builder != null) {
+                    builder.updateWithTotalFlightsMax(date, 0, entry.getValue(), 0);
+                }
+            }
         }
     }
 
@@ -799,11 +1040,28 @@ public class EventStatistics {
             totalEventsMap.merge(key, totalEvents, Integer::sum);
         }
 
+        public void updateWithTotalFlightsMax(String key, int flightsWithEvent, int totalFlights, int totalEvents) {
+            keys.add(key);
+
+            flightsWithEventMap.merge(key, flightsWithEvent, Integer::sum);
+            totalFlightsMap.merge(key, totalFlights, Math::max);
+            totalEventsMap.merge(key, totalEvents, Integer::sum);
+        }
+
         public void updateAggregate(String key, int flightsWithEvent, int totalFlights, int totalEvents) {
             keys.add(key);
 
             aggregateFlightsWithEventMap.merge(key, flightsWithEvent, Integer::sum);
             aggregateTotalFlightsMap.merge(key, totalFlights, Integer::sum);
+            aggregateTotalEventsMap.merge(key, totalEvents, Integer::sum);
+        }
+
+        public void updateAggregateWithTotalFlightsMax(
+                String key, int flightsWithEvent, int totalFlights, int totalEvents) {
+            keys.add(key);
+
+            aggregateFlightsWithEventMap.merge(key, flightsWithEvent, Integer::sum);
+            aggregateTotalFlightsMap.merge(key, totalFlights, Math::max);
             aggregateTotalEventsMap.merge(key, totalEvents, Integer::sum);
         }
     }

--- a/ngafid-www/src/test/kotlin/org/ngafid/www/EventStatisticsTest.kt
+++ b/ngafid-www/src/test/kotlin/org/ngafid/www/EventStatisticsTest.kt
@@ -1,0 +1,234 @@
+package org.ngafid.www
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.LocalDate
+
+class EventStatisticsTest {
+    @Test
+    fun monthlyEventCountsUseOneAggregateFlightDenominatorAcrossFleetRows() {
+        createConnection().use { connection ->
+            createSchema(connection)
+            insertMonthlyFlightCounts(connection)
+            insertMonthlyEventCounts(connection)
+            insertRawAnyEventData(connection)
+
+            val counts =
+                EventStatistics.getMonthlyEventCounts(
+                    connection,
+                    1,
+                    LocalDate.of(2025, 1, 1),
+                    LocalDate.of(2025, 3, 1),
+                    mapOf(AIRFRAME_ID to AIRFRAME_NAME),
+                    mapOf(EVENT_DEFINITION_ID to EVENT_NAME),
+                )
+
+            val hardLanding = counts.getValue(EVENT_NAME).getValue(AIRFRAME_NAME)
+            assertEquals(listOf("2025-01-01", "2025-02-01"), dates(hardLanding))
+            assertArrayEquals(intArrayOf(6, 0), intArray(hardLanding, "aggregateFlightsWithEventCounts"))
+            assertArrayEquals(intArrayOf(8, 0), intArray(hardLanding, "aggregateTotalEventsCounts"))
+            assertArrayEquals(intArrayOf(300, 30), intArray(hardLanding, "aggregateTotalFlightsCounts"))
+            assertArrayEquals(intArrayOf(2, 0), intArray(hardLanding, "flightsWithEventCounts"))
+            assertArrayEquals(intArrayOf(3, 0), intArray(hardLanding, "totalEventsCounts"))
+            assertArrayEquals(intArrayOf(100, 10), intArray(hardLanding, "totalFlightsCounts"))
+
+            val anyEvent = counts.getValue("ANY Event").getValue(AIRFRAME_NAME)
+            assertEquals(listOf("2025-01-01", "2025-02-01"), dates(anyEvent))
+            assertArrayEquals(intArrayOf(4, 0), intArray(anyEvent, "aggregateFlightsWithEventCounts"))
+            assertArrayEquals(intArrayOf(5, 0), intArray(anyEvent, "aggregateTotalEventsCounts"))
+            assertArrayEquals(intArrayOf(300, 30), intArray(anyEvent, "aggregateTotalFlightsCounts"))
+            assertArrayEquals(intArrayOf(2, 0), intArray(anyEvent, "flightsWithEventCounts"))
+            assertArrayEquals(intArrayOf(3, 0), intArray(anyEvent, "totalEventsCounts"))
+            assertArrayEquals(intArrayOf(100, 10), intArray(anyEvent, "totalFlightsCounts"))
+        }
+    }
+
+    @Test
+    fun aggregatePageMonthlyEventCountsDoNotPopulateFleetSpecificAnyEventCounts() {
+        createConnection().use { connection ->
+            createSchema(connection)
+            insertMonthlyFlightCounts(connection)
+            insertMonthlyEventCounts(connection)
+            insertRawAnyEventData(connection)
+
+            val counts =
+                EventStatistics.getMonthlyEventCounts(
+                    connection,
+                    -1,
+                    LocalDate.of(2025, 1, 1),
+                    LocalDate.of(2025, 3, 1),
+                    mapOf(AIRFRAME_ID to AIRFRAME_NAME),
+                    mapOf(EVENT_DEFINITION_ID to EVENT_NAME),
+                )
+
+            val anyEvent = counts.getValue("ANY Event").getValue(AIRFRAME_NAME)
+            assertArrayEquals(intArrayOf(4, 0), intArray(anyEvent, "aggregateFlightsWithEventCounts"))
+            assertArrayEquals(intArrayOf(5, 0), intArray(anyEvent, "aggregateTotalEventsCounts"))
+            assertArrayEquals(intArrayOf(300, 30), intArray(anyEvent, "aggregateTotalFlightsCounts"))
+            assertArrayEquals(intArrayOf(0, 0), intArray(anyEvent, "flightsWithEventCounts"))
+            assertArrayEquals(intArrayOf(0, 0), intArray(anyEvent, "totalEventsCounts"))
+            assertArrayEquals(intArrayOf(0, 0), intArray(anyEvent, "totalFlightsCounts"))
+        }
+    }
+
+    @Test
+    fun anyEventMonthlyCountsIncludeFlightOnlyMonthsWhenNoEventsExistInRange() {
+        createConnection().use { connection ->
+            createSchema(connection)
+            insertMonthlyFlightCounts(connection)
+
+            val counts =
+                EventStatistics.getMonthlyEventCounts(
+                    connection,
+                    1,
+                    LocalDate.of(2025, 2, 1),
+                    LocalDate.of(2025, 3, 1),
+                    mapOf(AIRFRAME_ID to AIRFRAME_NAME),
+                    mapOf(EVENT_DEFINITION_ID to EVENT_NAME),
+                )
+
+            val anyEvent = counts.getValue("ANY Event").getValue(AIRFRAME_NAME)
+            assertEquals(listOf("2025-02-01"), dates(anyEvent))
+            assertArrayEquals(intArrayOf(0), intArray(anyEvent, "aggregateFlightsWithEventCounts"))
+            assertArrayEquals(intArrayOf(0), intArray(anyEvent, "aggregateTotalEventsCounts"))
+            assertArrayEquals(intArrayOf(30), intArray(anyEvent, "aggregateTotalFlightsCounts"))
+            assertArrayEquals(intArrayOf(0), intArray(anyEvent, "flightsWithEventCounts"))
+            assertArrayEquals(intArrayOf(0), intArray(anyEvent, "totalEventsCounts"))
+            assertArrayEquals(intArrayOf(10), intArray(anyEvent, "totalFlightsCounts"))
+        }
+    }
+
+    private fun createConnection(): Connection =
+        DriverManager.getConnection(
+            "jdbc:h2:mem:${System.nanoTime()};MODE=MYSQL;NON_KEYWORDS=YEAR,MONTH;DATABASE_TO_UPPER=FALSE",
+        )
+
+    private fun createSchema(connection: Connection) {
+        connection.createStatement().use { statement ->
+            statement.execute(
+                """
+                CREATE TABLE m_fleet_monthly_flight_counts (
+                    fleet_id INT NOT NULL,
+                    airframe_id INT NOT NULL,
+                    year INT NOT NULL,
+                    month INT NOT NULL,
+                    count INT NOT NULL
+                )
+                """.trimIndent(),
+            )
+            statement.execute(
+                """
+                CREATE TABLE m_fleet_airframe_monthly_event_counts (
+                    fleet_id INT NOT NULL,
+                    event_definition_id INT NOT NULL,
+                    airframe_id INT NOT NULL,
+                    year INT NOT NULL,
+                    month INT NOT NULL,
+                    event_count INT NOT NULL,
+                    flight_count INT NOT NULL
+                )
+                """.trimIndent(),
+            )
+            statement.execute(
+                """
+                CREATE TABLE flights (
+                    id INT NOT NULL,
+                    airframe_id INT NOT NULL
+                )
+                """.trimIndent(),
+            )
+            statement.execute(
+                """
+                CREATE TABLE events (
+                    id INT NOT NULL,
+                    fleet_id INT NOT NULL,
+                    flight_id INT NOT NULL,
+                    start_time TIMESTAMP NOT NULL
+                )
+                """.trimIndent(),
+            )
+        }
+    }
+
+    private fun insertMonthlyFlightCounts(connection: Connection) {
+        connection.createStatement().use { statement ->
+            statement.execute(
+                """
+                INSERT INTO m_fleet_monthly_flight_counts
+                    (fleet_id, airframe_id, year, month, count)
+                VALUES
+                    (1, 10, 2025, 1, 100),
+                    (2, 10, 2025, 1, 200),
+                    (1, 10, 2025, 2, 10),
+                    (2, 10, 2025, 2, 20)
+                """.trimIndent(),
+            )
+        }
+    }
+
+    private fun insertMonthlyEventCounts(connection: Connection) {
+        connection.createStatement().use { statement ->
+            statement.execute(
+                """
+                INSERT INTO m_fleet_airframe_monthly_event_counts
+                    (fleet_id, event_definition_id, airframe_id, year, month, event_count, flight_count)
+                VALUES
+                    (1, 7, 10, 2025, 1, 3, 2),
+                    (2, 7, 10, 2025, 1, 5, 4)
+                """.trimIndent(),
+            )
+        }
+    }
+
+    private fun insertRawAnyEventData(connection: Connection) {
+        connection.createStatement().use { statement ->
+            statement.execute(
+                """
+                INSERT INTO flights (id, airframe_id)
+                VALUES
+                    (1, 10),
+                    (2, 10),
+                    (3, 10),
+                    (4, 10)
+                """.trimIndent(),
+            )
+            statement.execute(
+                """
+                INSERT INTO events (id, fleet_id, flight_id, start_time)
+                VALUES
+                    (101, 1, 1, '2025-01-05 00:00:00'),
+                    (102, 1, 1, '2025-01-06 00:00:00'),
+                    (103, 1, 2, '2025-01-07 00:00:00'),
+                    (104, 2, 3, '2025-01-08 00:00:00'),
+                    (105, 2, 4, '2025-01-09 00:00:00')
+                """.trimIndent(),
+            )
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun dates(counts: EventStatistics.MonthlyEventCounts): List<String> {
+        val field = EventStatistics.MonthlyEventCounts::class.java.getDeclaredField("dates")
+        field.isAccessible = true
+        return field.get(counts) as List<String>
+    }
+
+    private fun intArray(
+        counts: EventStatistics.MonthlyEventCounts,
+        fieldName: String,
+    ): IntArray {
+        val field = EventStatistics.EventCountsWithAggregate::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(counts) as IntArray
+    }
+
+    private companion object {
+        private const val AIRFRAME_ID = 10
+        private const val AIRFRAME_NAME = "Cessna 172S"
+        private const val EVENT_DEFINITION_ID = 7
+        private const val EVENT_NAME = "Hard Landing"
+    }
+}


### PR DESCRIPTION
- Avoid double-counting total-flight denominators when merging monthly event rows.
- Add Backend provided `ANY Event` monthly counts using distinct flights with events.
- Preserve flight-only months so months with no events still show the correct total flight count.
- Filter raw `ANY Event` queries by timestamp before grouping to improve performance.
