### PR TITLE
bug fix time rollover

### DIFF
--- a/ngafid-data-processor/src/main/java/org/ngafid/processor/format/RotorcraftCSVFileProcessor.java
+++ b/ngafid-data-processor/src/main/java/org/ngafid/processor/format/RotorcraftCSVFileProcessor.java
@@ -1034,6 +1034,9 @@ public final class RotorcraftCSVFileProcessor extends CSVFileProcessor {
         StringTimeSeries utcCanonical =
                 new StringTimeSeries(Parameters.UTC_DATE_TIME, Parameters.Unit.UTC_DATE_TIME.toString());
 
+        LocalDate currentDate = flightDate.get();
+        LocalTime previousTime = null;
+
         for (int i = 0; i < analogTime.size(); i++) {
             String sample = analogTime.get(i);
             if (sample == null || sample.isBlank()) {
@@ -1044,7 +1047,11 @@ public final class RotorcraftCSVFileProcessor extends CSVFileProcessor {
 
             try {
                 LocalTime time = LocalTime.parse(sample.trim(), METRO_ANALOG_TIME);
-                LocalDateTime local = LocalDateTime.of(flightDate.get(), time);
+                if (previousTime != null && time.isBefore(previousTime)) {
+                    currentDate = currentDate.plusDays(1);
+                }
+                LocalDateTime local = LocalDateTime.of(currentDate, time);
+                previousTime = time;
                 OffsetDateTime utc = OffsetDateTime.of(local, ZoneOffset.UTC);
                 unixCanonical.add(utc.toEpochSecond());
                 utcCanonical.add(utc.format(TimeUtils.ISO_8601_FORMAT));

--- a/ngafid-data-processor/src/main/java/org/ngafid/processor/steps/ComputeStartEndTime.java
+++ b/ngafid-data-processor/src/main/java/org/ngafid/processor/steps/ComputeStartEndTime.java
@@ -62,6 +62,10 @@ public class ComputeStartEndTime extends ComputeStep {
         var startODT = OffsetDateTime.parse(utc.get(start), TimeUtils.ISO_8601_FORMAT);
         var endODT = OffsetDateTime.parse(utc.get(end), TimeUtils.ISO_8601_FORMAT);
 
+        if (endODT.isBefore(startODT)) {
+            endODT = endODT.plusDays(1);
+        }
+
         builder.setStartDateTime(startODT).setEndDateTime(endODT);
     }
 }


### PR DESCRIPTION
Metro Aviation CSVs store time-only samples (Analog-time / ANALOG.UTC) and take the flight date from the filename token (yyyyMMddTHHmmss, e.g. 0131_20240825T235600_OTL_HAA.csv). When a flight crossed midnight, every row after midnight kept the filename date, so end_time could end up before start_time and produce negative flight hours.

This PR:

- Advances the canonical date in addCanonicalTimeFromMetroAnalogTime() when a sample time is earlier than the previous row (midnight crossover).

- Adds a safety net in ComputeStartEndTime: if parsed end is still before start, add one day to end (same pattern as Scan Eagle).