### PR TITLE
Improve upload outcome reporting, status resolution, and dashboard statistics

### DIFF
--- a/ngafid-core/src/main/java/org/ngafid/core/uploads/Upload.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/uploads/Upload.java
@@ -203,15 +203,18 @@ public final class Upload {
         public void reset() throws SQLException {
             this.clearUpload();
 
-            // Already enqueued, exit
-            if (status == Status.ENQUEUED) return;
-
-            final String query = "UPDATE uploads SET status = '" + Status.ENQUEUED + "' WHERE id = ?";
+            final String query = "UPDATE uploads SET status = ?, n_valid_flights = 0, "
+                    + "n_warning_flights = 0, n_error_flights = 0 WHERE id = ?";
             try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
-                preparedStatement.setInt(1, id);
+                preparedStatement.setString(1, Status.ENQUEUED.name());
+                preparedStatement.setInt(2, id);
                 LOG.info(preparedStatement.toString());
                 preparedStatement.executeUpdate();
             }
+            status = Status.ENQUEUED;
+            validFlights = 0;
+            warningFlights = 0;
+            errorFlights = 0;
         }
 
         private static KafkaProducer<String, Integer> producer = null;

--- a/ngafid-data-processor/src/main/java/org/ngafid/processor/ProcessUpload.java
+++ b/ngafid-data-processor/src/main/java/org/ngafid/processor/ProcessUpload.java
@@ -217,17 +217,6 @@ public final class ProcessUpload {
                 warningFlights = pipeline.getWarningFlightsCount();
                 validFlights = pipeline.getValidFlightsCount();
 
-                if (status == Upload.Status.PROCESSED_OK
-                        && pipeline.getFilesQueued() > 0
-                        && validFlights == 0
-                        && errorFlights == 0) {
-                    status = Upload.Status.FAILED_UNKNOWN;
-                    UploadError.insertError(
-                            connection,
-                            uploadId,
-                            "No flights were imported from the archive. Check upload consumer logs for errors.");
-                }
-
             } catch (java.nio.file.NoSuchFileException e) {
                 LOG.log(Level.SEVERE, "NoSuchFileException: {0}", e.toString());
                 e.printStackTrace();
@@ -342,6 +331,12 @@ public final class ProcessUpload {
         }
 
         if (status == Upload.Status.PROCESSED_OK) {
+            if (validFlights == 0 && warningFlights == 0 && errorFlights == 0) {
+                UploadError.insertError(
+                        connection,
+                        uploadId,
+                        "No flights were imported from the archive. Check the archive contents and upload consumer logs.");
+            }
             status = resolveStatusFromFlightCounts(validFlights, warningFlights, errorFlights);
         }
 
@@ -357,7 +352,7 @@ public final class ProcessUpload {
      * @return the upload status derived from the flight counts
      */
     static Upload.Status resolveStatusFromFlightCounts(int validFlights, int warningFlights, int errorFlights) {
-        if (validFlights == 0 && errorFlights > 0) {
+        if (validFlights == 0 && warningFlights == 0) {
             return Upload.Status.FAILED_UNKNOWN;
         }
         if (warningFlights > 0 || errorFlights > 0) {

--- a/ngafid-data-processor/src/main/java/org/ngafid/processor/format/RotorcraftCSVFileProcessor.java
+++ b/ngafid-data-processor/src/main/java/org/ngafid/processor/format/RotorcraftCSVFileProcessor.java
@@ -155,7 +155,7 @@ public final class RotorcraftCSVFileProcessor extends CSVFileProcessor {
      */
     public static boolean isRotorcraftUpload(Connection connection, String filename, BufferedReader reader)
             throws SQLException, IOException, FatalFlightFileException {
-        Optional<ParsedFilename> parsed = parseFilename(filename);
+        Optional<ParsedFilename> registeredIdentity = resolveRegisteredFilenameIdentity(connection, filename);
         if (reader != null) {
             reader.mark(512 * 1024);
             try {
@@ -167,25 +167,28 @@ public final class RotorcraftCSVFileProcessor extends CSVFileProcessor {
                 if (isUscgFormat(firstLine)) {
                     throw fatalUscgRegistryMiss(peekUscgAircraftSerialAfterReset(reader));
                 }
-                if (parsed.isPresent()) {
-                    String tail = parsed.get().tail();
-                    if (RotorcraftTailAirframeRegistry.findRotorcraft(connection, tail)
-                            .isPresent()) {
-                        return true;
-                    }
+                if (registeredIdentity.isPresent()) {
+                    return true;
+                }
+
+                Optional<String> recorderAirframeName = peekGarminAirframeName(firstLine);
+                if (recorderAirframeName.flatMap(Airframes::resolveGarminRotorcraftAirframeCode).isPresent()) {
+                    throw fatalTailRegistryMiss(
+                            preferredFilenameTail(filename),
+                            filename,
+                            recorderAirframeName,
+                            describeRotorcraftCsvLayout(firstLine));
                 }
             } finally {
                 reader.reset();
             }
         }
-        if (parsed.isPresent()
-                && RotorcraftTailAirframeRegistry.findRotorcraft(
-                                connection, parsed.get().tail())
-                        .isPresent()) {
+        if (registeredIdentity.isPresent()) {
             return true;
         }
-        if (parsed.isPresent()) {
-            LOG.info(() -> "Filename tail prefix '" + parsed.get().tail() + "' from '" + filename
+        String filenameTail = preferredFilenameTail(filename);
+        if (!filenameTail.isEmpty()) {
+            LOG.info(() -> "Filename tail prefix '" + filenameTail + "' from '" + filename
                     + "' is not in tail_airframe_registry and the file start does not match a known rotorcraft CSV"
                     + " layout; standard CSV processing will be used.");
         }
@@ -547,13 +550,18 @@ public final class RotorcraftCSVFileProcessor extends CSVFileProcessor {
             if (isUscgFormat(firstLine)) {
                 throw fatalUscgRegistryMiss(peekUscgAircraftSerialAfterReset(reader));
             }
-            Optional<ParsedFilename> fromFilename = parseFilename(filename);
+            Optional<ParsedFilename> fromFilename = resolveRegisteredFilenameIdentity(connection, filename);
             if (fromFilename.isPresent()) {
-                String tail = fromFilename.get().tail();
-                if (RotorcraftTailAirframeRegistry.findRotorcraft(connection, tail)
-                        .isPresent()) {
-                    return fromFilename.get();
-                }
+                return fromFilename.get();
+            }
+
+            Optional<String> recorderAirframeName = peekGarminAirframeName(firstLine);
+            if (recorderAirframeName.flatMap(Airframes::resolveGarminRotorcraftAirframeCode).isPresent()) {
+                throw fatalTailRegistryMiss(
+                        preferredFilenameTail(filename),
+                        filename,
+                        recorderAirframeName,
+                        describeRotorcraftCsvLayout(firstLine));
             }
         } finally {
             stream.reset();
@@ -725,6 +733,61 @@ public final class RotorcraftCSVFileProcessor extends CSVFileProcessor {
                     : base.substring(firstUnderscore + 1, secondUnderscore);
         }
         return Optional.of(new ParsedFilename(tail, systemId));
+    }
+
+    /**
+     * Resolves a registry identity from either the file prefix or its immediate parent directory. Garmin exports
+     * commonly use generic {@code log_*} basenames inside a tail-number directory.
+     */
+    static Optional<ParsedFilename> resolveRegisteredFilenameIdentity(Connection connection, String path)
+            throws SQLException {
+        Optional<ParsedFilename> parsed = parseFilename(path);
+        String systemId = parsed.map(ParsedFilename::systemId).orElse("");
+
+        for (String candidate : filenameTailCandidates(path)) {
+            Optional<RotorcraftTailAirframeRegistry.Entry> entry =
+                    RotorcraftTailAirframeRegistry.findRotorcraft(connection, candidate);
+            if (entry.isPresent()) {
+                return Optional.of(new ParsedFilename(entry.get().tail(), systemId));
+            }
+        }
+        return Optional.empty();
+    }
+
+    static List<String> filenameTailCandidates(String path) {
+        List<String> candidates = new ArrayList<>();
+        parseFilename(path).map(ParsedFilename::tail).ifPresent(tail -> addTailCandidate(candidates, tail));
+
+        String parent = immediateParentDirectory(path);
+        addTailCandidate(candidates, parent);
+        if (parent.length() > 1 && (parent.charAt(0) == 'N' || parent.charAt(0) == 'n')) {
+            addTailCandidate(candidates, parent.substring(1));
+        }
+        return candidates;
+    }
+
+    private static void addTailCandidate(List<String> candidates, String tail) {
+        if (tail != null && !tail.isBlank() && !candidates.contains(tail)) {
+            candidates.add(tail);
+        }
+    }
+
+    private static String immediateParentDirectory(String path) {
+        String normalized = path == null ? "" : path.replace('\\', '/');
+        int lastSlash = normalized.lastIndexOf('/');
+        if (lastSlash <= 0) {
+            return "";
+        }
+        int previousSlash = normalized.lastIndexOf('/', lastSlash - 1);
+        return normalized.substring(previousSlash + 1, lastSlash);
+    }
+
+    private static String preferredFilenameTail(String path) {
+        String parent = immediateParentDirectory(path);
+        if (!parent.isEmpty()) {
+            return parent;
+        }
+        return parseFilename(path).map(ParsedFilename::tail).orElse("");
     }
 
     /**

--- a/ngafid-db/src/changelogs/00-accounts/10-upload-statistics-indexes.sql
+++ b/ngafid-db/src/changelogs/00-accounts/10-upload-statistics-indexes.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset ngafid:uploads-fleet-start-time-index labels:accounts,uploads,performance
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'uploads' AND INDEX_NAME = 'idx_uploads_fleet_start_time'
+CREATE INDEX idx_uploads_fleet_start_time ON uploads (fleet_id, start_time);
+
+--changeset ngafid:uploads-start-time-index labels:accounts,uploads,performance
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'uploads' AND INDEX_NAME = 'idx_uploads_start_time'
+CREATE INDEX idx_uploads_start_time ON uploads (start_time);

--- a/ngafid-db/src/changelogs/01-flights/13-tail-airframe-registry.sql
+++ b/ngafid-db/src/changelogs/01-flights/13-tail-airframe-registry.sql
@@ -1049,8 +1049,8 @@ SELECT 'N365LL', a.id FROM airframes a WHERE a.airframe = 'AW119'
 ON DUPLICATE KEY UPDATE airframe_id = VALUES(airframe_id);
 
 --changeset ngafid:tail-airframe-registry-airframe-id-migrate labels:flights,airframes,tail-airframe-registry
+--preconditions onFail:MARK_RAN
 --precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tail_airframe_registry' AND COLUMN_NAME = 'airframe'
---precondition-on-fail:MARK_RAN
 --comment Migrate legacy varchar airframe FK to airframe_id (MySQL charset/FK compatibility)
 ALTER TABLE tail_airframe_registry ADD COLUMN airframe_id INT NULL;
 UPDATE tail_airframe_registry r

--- a/ngafid-frontend/src/imports.js
+++ b/ngafid-frontend/src/imports.js
@@ -424,6 +424,13 @@ class Import extends React.Component {
             statusClasses = statusStateUnknownDefaults.statusClasses;
         }
 
+        const errorFlightCount = Number(importInfo.errorFlights ?? 0);
+        if (status === "PROCESSED_WARNING" && errorFlightCount > 0) {
+            statusText = `Processed With ${errorFlightCount} Error${errorFlightCount === 1 ? "" : "s"}`;
+            colorClasses = "bg-danger";
+            statusClasses = "p-1 pl-2 pr-2 ml-1 card border-danger text-danger";
+        }
+
 
         const textClasses = "p-1 mr-1 card";
         const cardClasses = (textClasses + colorClasses);

--- a/ngafid-frontend/src/imports.js
+++ b/ngafid-frontend/src/imports.js
@@ -436,9 +436,11 @@ class Import extends React.Component {
         const cardClasses = (textClasses + colorClasses);
 
         console.log("Import Info: ", importInfo);
-        const totalFlights = (importInfo.validFlights + importInfo.errorFlights);
+        const warningFlights = Number(importInfo.warningFlights ?? 0);
+        const successfulFlights = Number(importInfo.validFlights ?? 0) + warningFlights;
+        const totalFlights = successfulFlights + Number(importInfo.errorFlights ?? 0);
 
-        const hasWarnings = (importInfo.warningFlights > 0);
+        const hasWarnings = (warningFlights > 0);
 
         return (
             <div className="m-2">
@@ -483,7 +485,7 @@ class Import extends React.Component {
                                          title="No Flights in this upload have Warnings."/>
                             }
                             <div>&nbsp;Valid:</div>
-                            <div style={{textAlign: "end", width: "100%"}}>{importInfo.validFlights}&nbsp;</div>
+                            <div style={{textAlign: "end", width: "100%"}}>{successfulFlights}&nbsp;</div>
                         </div>
 
                         {/* Flights Uploaded With Warnings */}

--- a/ngafid-frontend/src/imports.js
+++ b/ngafid-frontend/src/imports.js
@@ -183,6 +183,29 @@ class UploadErrors extends React.Component {
     }
 }
 
+/**
+ * Resolve statuses from persisted flight counters so imports created before the
+ * processor status fix do not continue to appear as successfully processed.
+ */
+function resolveImportDisplayStatus(importInfo) {
+    const status = importInfo.status;
+    if (status !== "PROCESSED_OK") {
+        return status;
+    }
+
+    const errorFlights = Number(importInfo.errorFlights ?? 0);
+    const warningFlights = Number(importInfo.warningFlights ?? 0);
+    const validFlights = Number(importInfo.validFlights ?? 0);
+
+    if (errorFlights > 0 && validFlights + warningFlights === 0) {
+        return "FAILED_UNKNOWN";
+    }
+    if (errorFlights > 0 || warningFlights > 0) {
+        return "PROCESSED_WARNING";
+    }
+    return status;
+}
+
 class Import extends React.Component {
     constructor(props) {
         super(props);
@@ -319,7 +342,7 @@ class Import extends React.Component {
             expandDivClasses = "m-0";
         }
 
-        const status = importInfo.status;
+        const status = resolveImportDisplayStatus(importInfo);
 
         /*
 

--- a/ngafid-frontend/src/summary_page.tsx
+++ b/ngafid-frontend/src/summary_page.tsx
@@ -45,6 +45,7 @@ const targetValues = {
     uploadsOK: "/api/upload/count/success",
     uploadsNotImported: "/api/upload/count/pending",
     uploadsWithError: "/api/upload/count/error",
+    importedFlights: "/api/flight/count/imported",
     flightsWithWarning: "/api/flight/count/with-warning",
     flightsWithError: "/api/flight/count/with-error",
 };
@@ -370,6 +371,7 @@ type SummaryPageState = {
         uploadsOK: number;
         uploadsNotImported: number;
         uploadsWithError: number;
+        importedFlights: number;
         flightsWithWarning: number;
         flightsWithError: number;
     };
@@ -407,6 +409,7 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
                 uploadsOK: number;
                 uploadsNotImported: number;
                 uploadsWithError: number;
+                importedFlights: number;
                 flightsWithWarning: number;
                 flightsWithError: number;
             }),
@@ -734,17 +737,17 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
 
         for await (const [stat, route] of Object.entries(targetValues)) {
 
-            const successResponseHandler = (response: { err_msg: string; err_title: string; }) => {
+            const successResponseHandler = (response: { err_msg?: string; err_title?: string; } | number | string) => {
 
                 console.log("Got response for statistic: ", stat, response);
 
-                if (response.err_msg) {
-                    showErrorModal(response.err_title, response.err_msg);
+                if (typeof response === "object" && response.err_msg) {
+                    showErrorModal(response.err_title ?? "Error Loading Statistic", response.err_msg);
                     return;
                 }
 
-                const result: { [key: string]: string } = {};
-                result[stat] = (typeof response === "string" ? response : JSON.stringify(response));
+                const result: { [key: string]: number } = {};
+                result[stat] = Number(response);
                 this.setState(prev => ({
                     statistics: {...prev.statistics, ...result}
                 }));
@@ -997,7 +1000,8 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
 
     UploadsSummary() {
 
-        const totalFlights = (this.state.statistics.numberFlights + this.state.statistics.flightsWithError);
+        const totalFlights = Number(this.state.statistics.importedFlights)
+            + Number(this.state.statistics.flightsWithError);
         const hasWarnings = (this.state.statistics.flightsWithWarning > 0);
 
         //Modifes a string to be plural if the supplied is not 1
@@ -1080,10 +1084,10 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
                                                         style={{alignContent: "center", color: "white"}}
                                                         title="No Flights in this Fleet have Warnings."/>
                                             }
-                                            &nbsp;{formatNumberAsync(this.state.statistics.numberFlights, integerOptions)}
+                                            &nbsp;{formatNumberAsync(this.state.statistics.importedFlights, integerOptions)}
                                         </span>
                                 </td>
-                                <td style={{paddingBottom: "6"}}>&nbsp;{pluralize(this.state.statistics.numberFlights, "Flight")}
+                                <td style={{paddingBottom: "6"}}>&nbsp;{pluralize(this.state.statistics.importedFlights, "Flight")}
                                     &nbsp;Valid
                                 </td>
                             </tr>

--- a/ngafid-frontend/src/summary_page.tsx
+++ b/ngafid-frontend/src/summary_page.tsx
@@ -41,13 +41,17 @@ const targetValues = {
     monthEvents: "/api/event/count/past-month",
     numberFleets: "/api/fleet/count",
     numberUsers: "/api/user/count",
-    uploads: "/api/upload/count",
-    uploadsOK: "/api/upload/count/success",
-    uploadsNotImported: "/api/upload/count/pending",
-    uploadsWithError: "/api/upload/count/error",
-    importedFlights: "/api/flight/count/imported",
-    flightsWithWarning: "/api/flight/count/with-warning",
-    flightsWithError: "/api/flight/count/with-error",
+};
+
+type UploadOutcomeCounts = {
+    uploadCount: number;
+    okUploadCount: number;
+    warningUploadCount: number;
+    failedUploadCount: number;
+    errorUploadCount: number;
+    successfulFlightCount: number;
+    warningFlightCount: number;
+    errorFlightCount: number;
 };
 
 const LOADING_STRING = "...";
@@ -392,7 +396,16 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
         this.state = {
             airframe: airframes[0],
             datesOrAirframeChanged: false,
-            statistics: Object.keys(targetValues).reduce((o, key) => ({...o, [key]: ""}), {} as {
+            statistics: {
+                ...Object.keys(targetValues).reduce((o, key) => ({...o, [key]: ""}), {}),
+                uploads: "",
+                uploadsOK: "",
+                uploadsNotImported: "",
+                uploadsWithError: "",
+                importedFlights: "",
+                flightsWithWarning: "",
+                flightsWithError: ""
+            } as unknown as {
                 flightTime: number;
                 yearFlightTime: number;
                 monthFlightTime: number;
@@ -412,7 +425,7 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
                 importedFlights: number;
                 flightsWithWarning: number;
                 flightsWithError: number;
-            }),
+            },
             flightHoursByAirframe: [],
             aggregateFlightHoursByAirframe: [],
             eventCounts: {},
@@ -420,7 +433,6 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
         };
 
         this.dateChange();
-        this.fetchStatistics();
 
     }
 
@@ -767,6 +779,37 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
             );
 
         }
+
+        fetchStatistic<UploadOutcomeCounts>(
+            "uploadOutcomes",
+            "/api/upload/outcomes",
+            this.props.aggregate,
+            this.state.airframe,
+            startYear,
+            startMonth,
+            endYear,
+            endMonth,
+            response => {
+                const uploadCount = Number(response.uploadCount);
+                const okUploadCount = Number(response.okUploadCount);
+                const warningUploadCount = Number(response.warningUploadCount);
+                const failedUploadCount = Number(response.failedUploadCount);
+
+                this.setState(prev => ({
+                    statistics: {
+                        ...prev.statistics,
+                        uploads: uploadCount,
+                        uploadsOK: okUploadCount,
+                        uploadsNotImported:
+                            uploadCount - okUploadCount - warningUploadCount - failedUploadCount,
+                        uploadsWithError: Number(response.errorUploadCount),
+                        importedFlights: Number(response.successfulFlightCount),
+                        flightsWithWarning: Number(response.warningFlightCount),
+                        flightsWithError: Number(response.errorFlightCount)
+                    }
+                }));
+            }
+        );
 
     }
 

--- a/ngafid-frontend/src/uploads.js
+++ b/ngafid-frontend/src/uploads.js
@@ -438,11 +438,11 @@ function resolveUploadDisplayStatus(uploadInfo) {
         return status;
     }
 
-    const errorFlights = uploadInfo.errorFlights ?? 0;
-    const warningFlights = uploadInfo.warningFlights ?? 0;
-    const validFlights = uploadInfo.validFlights ?? 0;
+    const errorFlights = Number(uploadInfo.errorFlights ?? 0);
+    const warningFlights = Number(uploadInfo.warningFlights ?? 0);
+    const validFlights = Number(uploadInfo.validFlights ?? 0);
 
-    if (errorFlights > 0 && validFlights === 0) {
+    if (errorFlights > 0 && validFlights + warningFlights === 0) {
         return "FAILED_UNKNOWN";
     }
     if (errorFlights > 0 || warningFlights > 0) {

--- a/ngafid-frontend/src/uploads.js
+++ b/ngafid-frontend/src/uploads.js
@@ -293,6 +293,13 @@ class Upload extends React.Component {
             statusClasses = statusStateUnknownDefaults.statusClasses;
         }
 
+        const errorFlightCount = Number(uploadInfo.errorFlights ?? 0);
+        if (status === "PROCESSED_WARNING" && errorFlightCount > 0) {
+            statusText = `Processed With ${errorFlightCount} Error${errorFlightCount === 1 ? "" : "s"}`;
+            progressBarClasses = "progress-bar bg-danger";
+            statusClasses = "p-1 pl-2 pr-2 ml-1 card border-danger text-danger";
+        }
+
 
         const progressSizeStyle = {
             width: `${width  }%`,

--- a/ngafid-www/src/main/java/org/ngafid/www/routes/StatisticsJavalinRoutes.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/routes/StatisticsJavalinRoutes.java
@@ -214,7 +214,7 @@ public class StatisticsJavalinRoutes {
         }
 
         public Integer uploadsWithError() throws SQLException {
-            return getUploadCounts().errorUploadCount();
+            return getUploadIssueCounts().errorUploadCount();
         }
 
         public Integer uploadsWithWarning() throws SQLException {
@@ -222,11 +222,21 @@ public class StatisticsJavalinRoutes {
         }
 
         public Integer flightsWithWarning() throws SQLException {
-            return getUploadCounts().warningUploadCount();
+            return getUploadIssueCounts().warningFlightCount();
         }
 
         public Integer flightsWithError() throws SQLException {
-            return getUploadCounts().errorUploadCount();
+            return getUploadIssueCounts().errorFlightCount();
+        }
+
+        private UploadStatistics.UploadIssueCounts getUploadIssueCounts() throws SQLException {
+            final String startDateIn = context.queryParam("startDate");
+            final String endDateIn = context.queryParam("endDate");
+
+            final LocalDate startDate = startDateIn != null ? LocalDate.parse(startDateIn) : LocalDate.MIN;
+            final LocalDate endDate = endDateIn != null ? LocalDate.parse(endDateIn) : LocalDate.MAX;
+
+            return UploadStatistics.getUploadIssueCountsDated(connection, fleetId, startDate, endDate);
         }
     }
 

--- a/ngafid-www/src/main/java/org/ngafid/www/routes/StatisticsJavalinRoutes.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/routes/StatisticsJavalinRoutes.java
@@ -221,6 +221,17 @@ public class StatisticsJavalinRoutes {
             return getUploadCounts().warningUploadCount();
         }
 
+        public UploadStatistics.UploadOutcomeCounts uploadOutcomes() throws SQLException {
+            final String startDateIn = context.queryParam("startDate");
+            final String endDateIn = context.queryParam("endDate");
+
+            final LocalDate startDate = startDateIn != null ? LocalDate.parse(startDateIn) : LocalDate.MIN;
+            final LocalDate endDate = endDateIn != null ? LocalDate.parse(endDateIn) : LocalDate.MAX;
+
+            return UploadStatistics.getUploadOutcomeCountsDated(
+                    connection, aggregate() ? null : fleetId, startDate, endDate);
+        }
+
         public Integer flightsWithWarning() throws SQLException {
             return getUploadIssueCounts().warningFlightCount();
         }

--- a/ngafid-www/src/main/java/org/ngafid/www/routes/StatisticsJavalinRoutes.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/routes/StatisticsJavalinRoutes.java
@@ -225,6 +225,10 @@ public class StatisticsJavalinRoutes {
             return getUploadIssueCounts().warningFlightCount();
         }
 
+        public Integer flightsImported() throws SQLException {
+            return getUploadIssueCounts().successfulFlightCount();
+        }
+
         public Integer flightsWithError() throws SQLException {
             return getUploadIssueCounts().errorFlightCount();
         }

--- a/ngafid-www/src/main/java/org/ngafid/www/uploads/UploadStatistics.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/uploads/UploadStatistics.java
@@ -15,6 +15,16 @@ public enum UploadStatistics {
     public record UploadIssueCounts(
             int errorUploadCount, int successfulFlightCount, int warningFlightCount, int errorFlightCount) {}
 
+    public record UploadOutcomeCounts(
+            int uploadCount,
+            int okUploadCount,
+            int warningUploadCount,
+            int failedUploadCount,
+            int errorUploadCount,
+            int successfulFlightCount,
+            int warningFlightCount,
+            int errorFlightCount) {}
+
     private static UploadCounts getUploadCountImpl(Connection connection, String tableName, String condition)
             throws SQLException {
         String query = "SELECT upload_count, ok_count, warning_count, error_count FROM " + tableName;
@@ -55,14 +65,34 @@ public enum UploadStatistics {
 
     private static UploadCounts getUploadCountsDatedImpl(
             Connection connection, Integer fleetId, LocalDate startDate, LocalDate endDate) throws SQLException {
+        UploadOutcomeCounts counts = getUploadOutcomeCountsDated(connection, fleetId, startDate, endDate);
+        return new UploadCounts(
+                counts.uploadCount(),
+                counts.okUploadCount(),
+                counts.warningUploadCount(),
+                counts.failedUploadCount());
+    }
+
+    /**
+     * Returns all upload and flight outcome totals in one query. Dashboard callers should use this method rather
+     * than issuing a separate aggregate query for each displayed value.
+     */
+    public static UploadOutcomeCounts getUploadOutcomeCountsDated(
+            Connection connection, Integer fleetId, LocalDate startDate, LocalDate endDate) throws SQLException {
         StringBuilder query = new StringBuilder("""
                 SELECT
-                    COALESCE(SUM(CASE WHEN status <> 'DERIVED' THEN 1 ELSE 0 END), 0) AS upload_count,
+                    COUNT(*) AS upload_count,
                     COALESCE(SUM(CASE WHEN status = 'PROCESSED_OK' THEN 1 ELSE 0 END), 0) AS ok_count,
                     COALESCE(SUM(CASE WHEN status = 'PROCESSED_WARNING' THEN 1 ELSE 0 END), 0) AS warning_count,
-                    COALESCE(SUM(CASE WHEN status LIKE 'FAILED%' THEN 1 ELSE 0 END), 0) AS error_count
+                    COALESCE(SUM(CASE WHEN status LIKE 'FAILED%' THEN 1 ELSE 0 END), 0) AS failed_count,
+                    COALESCE(SUM(CASE WHEN n_error_flights > 0 OR status LIKE 'FAILED%' THEN 1 ELSE 0 END), 0)
+                        AS error_upload_count,
+                    COALESCE(SUM(COALESCE(n_valid_flights, 0) + COALESCE(n_warning_flights, 0)), 0)
+                        AS successful_flight_count,
+                    COALESCE(SUM(n_warning_flights), 0) AS warning_flight_count,
+                    COALESCE(SUM(n_error_flights), 0) AS error_flight_count
                 FROM uploads
-                WHERE 1 = 1
+                WHERE status <> 'DERIVED'
                 """);
 
         boolean filterStart = !LocalDate.MIN.equals(startDate);
@@ -80,11 +110,15 @@ public enum UploadStatistics {
 
             try (ResultSet resultSet = statement.executeQuery()) {
                 resultSet.next();
-                return new UploadCounts(
+                return new UploadOutcomeCounts(
                         resultSet.getInt("upload_count"),
                         resultSet.getInt("ok_count"),
                         resultSet.getInt("warning_count"),
-                        resultSet.getInt("error_count"));
+                        resultSet.getInt("failed_count"),
+                        resultSet.getInt("error_upload_count"),
+                        resultSet.getInt("successful_flight_count"),
+                        resultSet.getInt("warning_flight_count"),
+                        resultSet.getInt("error_flight_count"));
             }
         }
     }
@@ -96,35 +130,12 @@ public enum UploadStatistics {
      */
     public static UploadIssueCounts getUploadIssueCountsDated(
             Connection connection, int fleetId, LocalDate startDate, LocalDate endDate) throws SQLException {
-        StringBuilder query = new StringBuilder("""
-                SELECT
-                    COALESCE(SUM(CASE WHEN n_error_flights > 0 OR status LIKE 'FAILED%' THEN 1 ELSE 0 END), 0),
-                    COALESCE(SUM(COALESCE(n_valid_flights, 0) + COALESCE(n_warning_flights, 0)), 0),
-                    COALESCE(SUM(n_warning_flights), 0),
-                    COALESCE(SUM(n_error_flights), 0)
-                FROM uploads
-                WHERE status <> 'DERIVED'
-                """);
-
-        boolean filterStart = !LocalDate.MIN.equals(startDate);
-        boolean filterEnd = !LocalDate.MAX.equals(endDate);
-        if (fleetId > 0) query.append(" AND fleet_id = ?");
-        if (filterStart) query.append(" AND start_time >= ?");
-        if (filterEnd) query.append(" AND start_time < ?");
-
-        try (PreparedStatement statement = connection.prepareStatement(query.toString())) {
-            int parameter = 1;
-            if (fleetId > 0) statement.setInt(parameter++, fleetId);
-            if (filterStart) statement.setTimestamp(parameter++, Timestamp.valueOf(startDate.atStartOfDay()));
-            if (filterEnd)
-                statement.setTimestamp(
-                        parameter, Timestamp.valueOf(endDate.plusDays(1).atStartOfDay()));
-
-            try (ResultSet resultSet = statement.executeQuery()) {
-                resultSet.next();
-                return new UploadIssueCounts(
-                        resultSet.getInt(1), resultSet.getInt(2), resultSet.getInt(3), resultSet.getInt(4));
-            }
-        }
+        UploadOutcomeCounts counts =
+                getUploadOutcomeCountsDated(connection, fleetId > 0 ? fleetId : null, startDate, endDate);
+        return new UploadIssueCounts(
+                counts.errorUploadCount(),
+                counts.successfulFlightCount(),
+                counts.warningFlightCount(),
+                counts.errorFlightCount());
     }
 }

--- a/ngafid-www/src/main/java/org/ngafid/www/uploads/UploadStatistics.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/uploads/UploadStatistics.java
@@ -1,7 +1,5 @@
 package org.ngafid.www.uploads;
 
-import static org.ngafid.www.routes.StatisticsJavalinRoutes.buildDateClause;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -14,7 +12,8 @@ public enum UploadStatistics {
 
     public record UploadCounts(int count, int okUploadCount, int warningUploadCount, int errorUploadCount) {}
 
-    public record UploadIssueCounts(int errorUploadCount, int warningFlightCount, int errorFlightCount) {}
+    public record UploadIssueCounts(
+            int errorUploadCount, int successfulFlightCount, int warningFlightCount, int errorFlightCount) {}
 
     private static UploadCounts getUploadCountImpl(Connection connection, String tableName, String condition)
             throws SQLException {
@@ -42,13 +41,7 @@ public enum UploadStatistics {
 
     public static UploadCounts getUploadCountsDated(
             Connection connection, int fleetId, LocalDate startDate, LocalDate endDate) throws SQLException {
-
-        String clause = buildDateClause(startDate, endDate);
-
-        // Append the fleet ID condition
-        clause += " AND fleet_id = " + fleetId;
-
-        return getUploadCountImpl(connection, "v_fleet_monthly_upload_counts", clause);
+        return getUploadCountsDatedImpl(connection, fleetId, startDate, endDate);
     }
 
     public static UploadCounts getAggregateUploadCounts(Connection connection) throws SQLException {
@@ -57,10 +50,43 @@ public enum UploadStatistics {
 
     public static UploadCounts getAggregateUploadCountsDated(
             Connection connection, LocalDate startDate, LocalDate endDate) throws SQLException {
+        return getUploadCountsDatedImpl(connection, null, startDate, endDate);
+    }
 
-        String clause = buildDateClause(startDate, endDate);
+    private static UploadCounts getUploadCountsDatedImpl(
+            Connection connection, Integer fleetId, LocalDate startDate, LocalDate endDate) throws SQLException {
+        StringBuilder query = new StringBuilder("""
+                SELECT
+                    COALESCE(SUM(CASE WHEN status <> 'DERIVED' THEN 1 ELSE 0 END), 0) AS upload_count,
+                    COALESCE(SUM(CASE WHEN status = 'PROCESSED_OK' THEN 1 ELSE 0 END), 0) AS ok_count,
+                    COALESCE(SUM(CASE WHEN status = 'PROCESSED_WARNING' THEN 1 ELSE 0 END), 0) AS warning_count,
+                    COALESCE(SUM(CASE WHEN status LIKE 'FAILED%' THEN 1 ELSE 0 END), 0) AS error_count
+                FROM uploads
+                WHERE 1 = 1
+                """);
 
-        return getUploadCountImpl(connection, "v_aggregate_monthly_upload_counts", clause);
+        boolean filterStart = !LocalDate.MIN.equals(startDate);
+        boolean filterEnd = !LocalDate.MAX.equals(endDate);
+        if (fleetId != null) query.append(" AND fleet_id = ?");
+        if (filterStart) query.append(" AND start_time >= ?");
+        if (filterEnd) query.append(" AND start_time < ?");
+
+        try (PreparedStatement statement = connection.prepareStatement(query.toString())) {
+            int parameter = 1;
+            if (fleetId != null) statement.setInt(parameter++, fleetId);
+            if (filterStart) statement.setTimestamp(parameter++, Timestamp.valueOf(startDate.atStartOfDay()));
+            if (filterEnd)
+                statement.setTimestamp(parameter, Timestamp.valueOf(endDate.plusDays(1).atStartOfDay()));
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return new UploadCounts(
+                        resultSet.getInt("upload_count"),
+                        resultSet.getInt("ok_count"),
+                        resultSet.getInt("warning_count"),
+                        resultSet.getInt("error_count"));
+            }
+        }
     }
 
     /**
@@ -73,6 +99,7 @@ public enum UploadStatistics {
         StringBuilder query = new StringBuilder("""
                 SELECT
                     COALESCE(SUM(CASE WHEN n_error_flights > 0 OR status LIKE 'FAILED%' THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(COALESCE(n_valid_flights, 0) + COALESCE(n_warning_flights, 0)), 0),
                     COALESCE(SUM(n_warning_flights), 0),
                     COALESCE(SUM(n_error_flights), 0)
                 FROM uploads
@@ -95,7 +122,8 @@ public enum UploadStatistics {
 
             try (ResultSet resultSet = statement.executeQuery()) {
                 resultSet.next();
-                return new UploadIssueCounts(resultSet.getInt(1), resultSet.getInt(2), resultSet.getInt(3));
+                return new UploadIssueCounts(
+                        resultSet.getInt(1), resultSet.getInt(2), resultSet.getInt(3), resultSet.getInt(4));
             }
         }
     }

--- a/ngafid-www/src/main/java/org/ngafid/www/uploads/UploadStatistics.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/uploads/UploadStatistics.java
@@ -6,12 +6,15 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 
 public enum UploadStatistics {
     ;
 
     public record UploadCounts(int count, int okUploadCount, int warningUploadCount, int errorUploadCount) {}
+
+    public record UploadIssueCounts(int errorUploadCount, int warningFlightCount, int errorFlightCount) {}
 
     private static UploadCounts getUploadCountImpl(Connection connection, String tableName, String condition)
             throws SQLException {
@@ -58,5 +61,42 @@ public enum UploadStatistics {
         String clause = buildDateClause(startDate, endDate);
 
         return getUploadCountImpl(connection, "v_aggregate_monthly_upload_counts", clause);
+    }
+
+    /**
+     * Returns issue totals for non-derived uploads in the requested fleet and date range: uploads that failed or
+     * contain rejected flights, flights with warnings, and rejected flights. The flight counters are used because
+     * {@code PROCESSED_WARNING} represents both warning-only and partially successful uploads.
+     */
+    public static UploadIssueCounts getUploadIssueCountsDated(
+            Connection connection, int fleetId, LocalDate startDate, LocalDate endDate) throws SQLException {
+        StringBuilder query = new StringBuilder("""
+                SELECT
+                    COALESCE(SUM(CASE WHEN n_error_flights > 0 OR status LIKE 'FAILED%' THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(n_warning_flights), 0),
+                    COALESCE(SUM(n_error_flights), 0)
+                FROM uploads
+                WHERE status <> 'DERIVED'
+                """);
+
+        boolean filterStart = !LocalDate.MIN.equals(startDate);
+        boolean filterEnd = !LocalDate.MAX.equals(endDate);
+        if (fleetId > 0) query.append(" AND fleet_id = ?");
+        if (filterStart) query.append(" AND start_time >= ?");
+        if (filterEnd) query.append(" AND start_time < ?");
+
+        try (PreparedStatement statement = connection.prepareStatement(query.toString())) {
+            int parameter = 1;
+            if (fleetId > 0) statement.setInt(parameter++, fleetId);
+            if (filterStart) statement.setTimestamp(parameter++, Timestamp.valueOf(startDate.atStartOfDay()));
+            if (filterEnd)
+                statement.setTimestamp(
+                        parameter, Timestamp.valueOf(endDate.plusDays(1).atStartOfDay()));
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return new UploadIssueCounts(resultSet.getInt(1), resultSet.getInt(2), resultSet.getInt(3));
+            }
+        }
     }
 }

--- a/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/FlightRoutes.kt
+++ b/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/FlightRoutes.kt
@@ -39,6 +39,7 @@ object FlightRoutes : RouteProvider() {
 
                 RouteUtility.getStat("count/past-month") { ctx, stats -> ctx.json(stats.monthNumberFlights()) }
                 RouteUtility.getStat("count/past-year") { ctx, stats -> ctx.json(stats.yearNumberFlights()) }
+                RouteUtility.getStat("count/imported") { ctx, stats -> ctx.json(stats.flightsImported()) }
                 RouteUtility.getStat("count/with-warning") { ctx, stats -> ctx.json(stats.flightsWithWarning()) }
                 RouteUtility.getStat("count/with-error") { ctx, stats -> ctx.json(stats.flightsWithError()) }
                 RouteUtility.getStat("count") { ctx, stats -> ctx.json(stats.numberFlights()) }

--- a/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/UploadRoutes.kt
+++ b/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/UploadRoutes.kt
@@ -58,6 +58,7 @@ object UploadRoutes : RouteProvider() {
                 RouteUtility.getStat("count/warning") { ctx, stats -> ctx.json(stats.uploadsWithWarning()) }
                 RouteUtility.getStat("count/error") { ctx, stats -> ctx.json(stats.uploadsWithError()) }
                 RouteUtility.getStat("count/pending") { ctx, stats -> ctx.json(stats.uploadsNotImported()) }
+                RouteUtility.getStat("outcomes") { ctx, stats -> ctx.json(stats.uploadOutcomes()) }
             }
         }
     }


### PR DESCRIPTION
Previously, uploads containing failed flights could still appear as successfully processed, warning flights were not consistently included in successful-flight totals, and several dashboard statistics represented upload counts instead of actual flight outcomes. Historical uploads with incorrect stored statuses could also continue to appear green.

This PR resolves those inconsistencies across the data processor, backend statistics API, uploads/imports interfaces, and summary dashboard. It also consolidates upload statistics into one indexed query to avoid repeatedly scanning the uploads table which significantly improves performance.

- Upload statuses are now properly obtained from valid, warning, and rejected flight counts.
- Resetting an upload for reprocessing now clears all previous counters.
- The uploads and imports pages now display flight outcomes consistently
  - Warning flights are included in the displayed successful/valid total.
  - Total flights include valid, warning, and rejected flights.
  - Partially successful uploads with rejected flight show the rejected flight count.
  - All-error uploads are displayed as failed.
- The imports page resolves from the persisted flight counters. This means even previous uploads should now show accurately.
- The Uploads summary now reports actual upload and flight outcomes instead of reusing upload-status counts as flight counts. This means partially successful uploads are correctly included in “Uploads with Errors.”
- A new statistics endpoint provides all upload-related dashboard values in one response. The summary page now calls the consolidated endpoint instead of issuing seven separate upload and flight-outcome requests.
- Previously, the dashboard requested each upload statistic independently. Because the summary page also started its initial statistics fetch twice, loading the page could trigger as many as 14 related database queries. This replaces seven upload-related requests with one request.

Imports Page
<img width="915" height="471" alt="image" src="https://github.com/user-attachments/assets/ac2d549c-00ff-4e91-a21f-819b7c808af2" />

Uploads Page
<img width="896" height="53" alt="image" src="https://github.com/user-attachments/assets/7e6fcdee-013b-4925-b7f2-9db435ed8518" />
