### PR TITLE
add aircraft type filter toggle

### DIFF
--- a/ngafid-core/src/main/java/org/ngafid/core/event/Event.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/event/Event.java
@@ -229,6 +229,25 @@ public class Event {
             LocalDate endTime,
             String tagName)
             throws SQLException {
+        return getEvents(
+                connection,
+                fleetId,
+                eventName,
+                startTime,
+                endTime,
+                tagName,
+                Airframes.AircraftCategory.ALL);
+    }
+
+    public static HashMap<String, ArrayList<Event>> getEvents(
+            Connection connection,
+            int fleetId,
+            String eventName,
+            LocalDate startTime,
+            LocalDate endTime,
+            String tagName,
+            Airframes.AircraftCategory aircraftCategory)
+            throws SQLException {
 
         // PERFORMANCE LOGGING: Track fetch time for this event type
         long startTimeMs = System.currentTimeMillis();
@@ -238,18 +257,16 @@ public class Event {
         LOG.info("========================================");
 
         // get list of airframes for this fleet so we can set up the hashmap of arraylists for events by airframe
-        ArrayList<String> fleetAirframes = Airframes.getAll(connection, fleetId);
         HashMap<Integer, String> airframeIds = new HashMap<>();
 
         // create the hashmap to be returned by this method
         HashMap<String, ArrayList<Event>> eventsByAirframe = new HashMap<>();
 
         // get a map of the airframe ids to airframe names
-        for (String airframe : fleetAirframes) {
-            airframeIds.put(
-                    Airframes.Airframe.getAirframeByName(connection, airframe).getId(), airframe);
-
-            eventsByAirframe.put(airframe, new ArrayList<>());
+        for (Airframes.TypedAirframeNameID airframe : Airframes.getAllWithIdsAndTypes(connection, fleetId)) {
+            if (!aircraftCategory.matches(airframe.type())) continue;
+            airframeIds.put(airframe.id(), airframe.name());
+            eventsByAirframe.put(airframe.name(), new ArrayList<>());
         }
 
         String query;
@@ -325,6 +342,7 @@ public class Event {
             }
         }
         eventsQuery += ") AND events.fleet_id = ?";
+        eventsQuery += " AND " + aircraftCategory.sqlCondition("flights.airframe_id");
 
         if (startTime != null) {
             eventsQuery += " AND events.end_time >= ?";

--- a/ngafid-core/src/main/java/org/ngafid/core/flights/Airframes.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/flights/Airframes.java
@@ -362,6 +362,67 @@ public final class Airframes {
         /*...*/
     }
 
+    /** An airframe name/id pair with its persisted aircraft type. */
+    public record TypedAirframeNameID(String name, int id, String type) {}
+
+    /**
+     * Dashboard-level aircraft categories. UAS intentionally groups both persisted UAS subtypes.
+     */
+    public enum AircraftCategory {
+        ALL("all"),
+        FIXED_WING("fixed-wing"),
+        ROTORCRAFT("rotorcraft"),
+        UAS("uas");
+
+        private final String queryValue;
+
+        AircraftCategory(String queryValue) {
+            this.queryValue = queryValue;
+        }
+
+        public String queryValue() {
+            return queryValue;
+        }
+
+        public static AircraftCategory fromQueryValue(String value) {
+            if (value == null || value.isBlank()) return ALL;
+            for (AircraftCategory category : values()) {
+                if (category.queryValue.equalsIgnoreCase(value)) return category;
+            }
+            return ALL;
+        }
+
+        public boolean matches(String typeName) {
+            if (this == ALL) return true;
+            if (typeName == null) return false;
+            return switch (this) {
+                case FIXED_WING -> typeName.equals("Fixed Wing");
+                case ROTORCRAFT -> typeName.equals("Rotorcraft");
+                case UAS -> typeName.startsWith("UAS ");
+                case ALL -> true;
+            };
+        }
+
+        /**
+         * Returns a safe SQL predicate for an airframe-id column. The column expression is supplied only by
+         * server code; no request value is interpolated into SQL.
+         */
+        public String sqlCondition(String airframeIdColumn) {
+            return switch (this) {
+                case ALL -> "1 = 1";
+                case FIXED_WING -> airframeIdColumn
+                        + " IN (SELECT a.id FROM airframes a INNER JOIN airframe_types t ON t.id = a.type_id"
+                        + " WHERE t.name = 'Fixed Wing')";
+                case ROTORCRAFT -> airframeIdColumn
+                        + " IN (SELECT a.id FROM airframes a INNER JOIN airframe_types t ON t.id = a.type_id"
+                        + " WHERE t.name = 'Rotorcraft')";
+                case UAS -> airframeIdColumn
+                        + " IN (SELECT a.id FROM airframes a INNER JOIN airframe_types t ON t.id = a.type_id"
+                        + " WHERE t.name IN ('UAS Fixed Wing', 'UAS Rotorcraft'))";
+            };
+        }
+    }
+
     public static final int FLEET_ID_ALL = -1;
 
     public static AirframeNameID[] getAllWithIds(Connection connection) throws SQLException {
@@ -435,6 +496,33 @@ public final class Airframes {
         }
 
         return airframes.toArray(AirframeNameID[]::new);
+    }
+
+    public static TypedAirframeNameID[] getAllWithIdsAndTypes(Connection connection) throws SQLException {
+        return getAllWithIdsAndTypes(connection, FLEET_ID_ALL);
+    }
+
+    public static TypedAirframeNameID[] getAllWithIdsAndTypes(Connection connection, int fleetId)
+            throws SQLException {
+        ArrayList<TypedAirframeNameID> airframes = new ArrayList<>();
+        String fleetJoin = fleetId == FLEET_ID_ALL
+                ? ""
+                : " INNER JOIN fleet_airframes fa ON fa.airframe_id = a.id ";
+        String fleetWhere = fleetId == FLEET_ID_ALL ? "" : " WHERE fa.fleet_id = ? ";
+        String queryString = "SELECT a.airframe, a.id, t.name AS type FROM airframes a "
+                + "INNER JOIN airframe_types t ON t.id = a.type_id "
+                + fleetJoin + fleetWhere + " ORDER BY a.airframe";
+
+        try (PreparedStatement query = connection.prepareStatement(queryString)) {
+            if (fleetId != FLEET_ID_ALL) query.setInt(1, fleetId);
+            try (ResultSet resultSet = query.executeQuery()) {
+                while (resultSet.next()) {
+                    airframes.add(new TypedAirframeNameID(
+                            resultSet.getString("airframe"), resultSet.getInt("id"), resultSet.getString("type")));
+                }
+            }
+        }
+        return airframes.toArray(TypedAirframeNameID[]::new);
     }
 
     public static ArrayList<String> getAll(Connection connection) throws SQLException {

--- a/ngafid-core/src/main/java/org/ngafid/core/flights/Flight.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/flights/Flight.java
@@ -197,8 +197,25 @@ public class Flight {
     public static List<Integer> getFlightIdsWithinDateRangeFromAirport(
             Connection connection, String startDate, String endDate, String airportIataCode, int limit, int offset)
             throws SQLException {
+        return getFlightIdsWithinDateRangeFromAirport(
+                connection, startDate, endDate, airportIataCode, limit, offset, null, Airframes.AircraftCategory.ALL);
+    }
+
+    public static List<Integer> getFlightIdsWithinDateRangeFromAirport(
+            Connection connection,
+            String startDate,
+            String endDate,
+            String airportIataCode,
+            int limit,
+            int offset,
+            Integer fleetId,
+            Airframes.AircraftCategory aircraftCategory)
+            throws SQLException {
         String extraCondition = buildDateRangeAirportCondition(startDate, endDate, airportIataCode);
-        String queryString = "SELECT id FROM flights WHERE (" + extraCondition + ") ORDER BY id DESC LIMIT " + limit;
+        String queryString = "SELECT id FROM flights WHERE (" + extraCondition + ") AND "
+                + aircraftCategory.sqlCondition("flights.airframe_id");
+        if (fleetId != null) queryString += " AND flights.fleet_id = " + fleetId;
+        queryString += " ORDER BY id DESC LIMIT " + limit;
         if (offset > 0) {
             queryString += " OFFSET " + offset;
         }
@@ -223,8 +240,22 @@ public class Flight {
      */
     public static int getFlightsCountWithinDateRangeFromAirport(
             Connection connection, String startDate, String endDate, String airportIataCode) throws SQLException {
+        return getFlightsCountWithinDateRangeFromAirport(
+                connection, startDate, endDate, airportIataCode, null, Airframes.AircraftCategory.ALL);
+    }
+
+    public static int getFlightsCountWithinDateRangeFromAirport(
+            Connection connection,
+            String startDate,
+            String endDate,
+            String airportIataCode,
+            Integer fleetId,
+            Airframes.AircraftCategory aircraftCategory)
+            throws SQLException {
         String extraCondition = buildDateRangeAirportCondition(startDate, endDate, airportIataCode);
-        String queryString = "SELECT COUNT(*) FROM flights WHERE (" + extraCondition + ")";
+        String queryString = "SELECT COUNT(*) FROM flights WHERE (" + extraCondition + ") AND "
+                + aircraftCategory.sqlCondition("flights.airframe_id");
+        if (fleetId != null) queryString += " AND flights.fleet_id = " + fleetId;
         try (PreparedStatement query = connection.prepareStatement(queryString);
                 ResultSet rs = query.executeQuery()) {
             rs.next();

--- a/ngafid-core/src/main/java/org/ngafid/core/flights/Tails.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/flights/Tails.java
@@ -317,6 +317,46 @@ public final class Tails {
         }
     }
 
+    /** Counts aircraft represented by flights in the selected dashboard category. */
+    public static int getNumberTails(Connection connection, int fleetId, Airframes.AircraftCategory category)
+            throws SQLException {
+        if (category == Airframes.AircraftCategory.ALL) return getNumberTails(connection, fleetId);
+
+        String queryString = "SELECT COUNT(*) FROM (SELECT f.fleet_id, f.system_id FROM flights f WHERE "
+                + category.sqlCondition("f.airframe_id");
+        if (fleetId > 0) queryString += " AND f.fleet_id = ?";
+        queryString += " GROUP BY f.fleet_id, f.system_id) selected_aircraft";
+
+        try (PreparedStatement query = connection.prepareStatement(queryString)) {
+            if (fleetId > 0) query.setInt(1, fleetId);
+            try (ResultSet resultSet = query.executeQuery()) {
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        }
+    }
+
+    /** Counts aircraft represented by flights for either an exact airframe or a dashboard category. */
+    public static int getNumberTails(
+            Connection connection, int fleetId, Airframes.AircraftCategory category, int airframeId)
+            throws SQLException {
+        if (airframeId < 0) return getNumberTails(connection, fleetId, category);
+
+        String queryString =
+                "SELECT COUNT(*) FROM (SELECT f.fleet_id, f.system_id FROM flights f WHERE f.airframe_id = ?";
+        if (fleetId > 0) queryString += " AND f.fleet_id = ?";
+        queryString += " GROUP BY f.fleet_id, f.system_id) selected_aircraft";
+
+        try (PreparedStatement query = connection.prepareStatement(queryString)) {
+            query.setInt(1, airframeId);
+            if (fleetId > 0) query.setInt(2, fleetId);
+            try (ResultSet resultSet = query.executeQuery()) {
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        }
+    }
+
     public static void removeUnused(Connection connection) throws SQLException {
         String queryString = "DELETE FROM tails WHERE NOT EXISTS "
                 + "(SELECT id FROM flights WHERE flights.system_id = tails.system_id "

--- a/ngafid-core/src/main/java/org/ngafid/core/heatmap/HeatmapPointsProcessor.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/heatmap/HeatmapPointsProcessor.java
@@ -11,6 +11,7 @@ import org.ngafid.core.Database;
 import org.ngafid.core.agl_converter.MSLtoAGLConverter;
 import org.ngafid.core.event.Event;
 import org.ngafid.core.event.EventMetaData;
+import org.ngafid.core.flights.Airframes;
 import org.ngafid.core.flights.DoubleTimeSeries;
 import org.ngafid.core.flights.Flight;
 import org.ngafid.core.flights.Parameters;
@@ -724,6 +725,7 @@ public class HeatmapPointsProcessor {
     public static List<Map<String, Object>> getEvents(
             int fleetId,
             String airframe,
+            Airframes.AircraftCategory aircraftCategory,
             List<Integer> eventDefinitionIds,
             java.sql.Date startDate,
             java.sql.Date endDate,
@@ -750,6 +752,7 @@ public class HeatmapPointsProcessor {
                     + "AND DATE(e.start_time) BETWEEN ? AND ? "
                     + "AND e.min_latitude <= ? AND e.max_latitude >= ? "
                     + "AND e.min_longitude <= ? AND e.max_longitude >= ?");
+            sql.append(" AND ").append(aircraftCategory.sqlCondition("f.airframe_id"));
             if (airframe != null && !airframe.isEmpty() && !airframe.equals("All Airframes")) {
                 sql.append(" AND a.airframe = ?");
             }

--- a/ngafid-core/src/main/java/org/ngafid/core/util/filters/Filter.java
+++ b/ngafid-core/src/main/java/org/ngafid/core/util/filters/Filter.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.TreeSet;
 import java.util.logging.Logger;
+import org.ngafid.core.flights.Airframes;
 
 public class Filter {
     private static final Logger LOG = Logger.getLogger(Filter.class.getName());
@@ -244,6 +245,19 @@ public class Filter {
                 } else {
                     return "flights.airframe_id != (SELECT id FROM airframes WHERE fleet_id = ? AND airframe = ?)";
                 }
+            }
+
+            case "Aircraft Type" -> {
+                Airframes.AircraftCategory category = switch (inputs.get(2)) {
+                    case "Fixed Wing" -> Airframes.AircraftCategory.FIXED_WING;
+                    case "Rotorcraft" -> Airframes.AircraftCategory.ROTORCRAFT;
+                    case "UAS" -> Airframes.AircraftCategory.UAS;
+                    default -> throw new IllegalArgumentException("Unknown aircraft type: " + inputs.get(2));
+                };
+                String predicate = category.sqlCondition("flights.airframe_id");
+                if (inputs.get(1).equals("is")) return predicate;
+                if (inputs.get(1).equals("is not")) return "NOT (" + predicate + ")";
+                throw new IllegalArgumentException("Unknown aircraft type condition: " + inputs.get(1));
             }
 
             case "System ID" -> {

--- a/ngafid-frontend/eslint.config.mjs
+++ b/ngafid-frontend/eslint.config.mjs
@@ -62,6 +62,7 @@ export default defineConfig([
                 aggregateView: 'readonly',
                 airframeMap: 'readonly',
                 airframes: 'readonly',
+                aircraftTypesByName: 'readonly',
                 airports: 'readonly',
                 airSyncEnabled: 'readonly',
                 airsyncTimeout: 'readonly',

--- a/ngafid-frontend/src/aircraft_type_filter.ts
+++ b/ngafid-frontend/src/aircraft_type_filter.ts
@@ -1,0 +1,36 @@
+import type { AirframeNameID } from "./types";
+
+export type AircraftCategory = "all" | "fixed-wing" | "rotorcraft" | "uas";
+
+export const AIRCRAFT_CATEGORIES: ReadonlyArray<{ value: AircraftCategory; label: string }> = [
+    { value: "all", label: "All" },
+    { value: "fixed-wing", label: "Fixed Wing" },
+    { value: "rotorcraft", label: "Rotorcraft" },
+    { value: "uas", label: "UAS" },
+];
+
+export function aircraftMatchesCategory(airframe: AirframeNameID, category: AircraftCategory): boolean {
+    if (category === "all" || airframe.id < 0)
+        return true;
+    return aircraftTypeMatchesCategory(airframe.type, category);
+}
+
+export function aircraftTypeMatchesCategory(
+    type: string | undefined,
+    category: AircraftCategory,
+): boolean {
+    if (category === "all")
+        return true;
+    if (category === "fixed-wing")
+        return type === "Fixed Wing";
+    if (category === "rotorcraft")
+        return type === "Rotorcraft";
+    return type?.startsWith("UAS ") === true;
+}
+
+export function airframesForCategory(
+    source: AirframeNameID[],
+    category: AircraftCategory,
+): AirframeNameID[] {
+    return source.filter(airframe => aircraftMatchesCategory(airframe, category));
+}

--- a/ngafid-frontend/src/flights.js
+++ b/ngafid-frontend/src/flights.js
@@ -69,6 +69,22 @@ const rules = [
     },
 
     {
+        name: "Aircraft Type",
+        conditions: [
+            {
+                type: "select",
+                name: "condition",
+                options: ["is", "is not"],
+            },
+            {
+                type: "select",
+                name: "aircraft type",
+                options: ["Fixed Wing", "Rotorcraft", "UAS"],
+            },
+        ],
+    },
+
+    {
         name: "Tail Number",
         conditions: [
             {

--- a/ngafid-frontend/src/heat_map.tsx
+++ b/ngafid-frontend/src/heat_map.tsx
@@ -12,11 +12,17 @@
 // =======================
 // SECTION: Imports
 // =======================
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { createRoot } from "react-dom/client";
 import SignedInNavbar from "./signed_in_navbar";
 import { TimeHeader } from "./time_header.js";
 import { showErrorModal } from "./error_modal.js";
+import type { AirframeNameID } from "./types";
+import {
+    AIRCRAFT_CATEGORIES,
+    airframesForCategory,
+    type AircraftCategory,
+} from "./aircraft_type_filter";
 
 // OpenLayers imports
 import Map from 'ol/Map';
@@ -330,14 +336,12 @@ const MARKER_VISIBILITY_ZOOM_THRESHOLD = 15;
 
 declare const azureMapsKey: string | undefined;
 
-// Airframes configuration - define airframes if not already defined
-declare const airframes: string[] | undefined;
-const airframesList = (typeof airframes !== 'undefined' && Array.isArray(airframes)) ? [...airframes] : [];
-if (!airframesList.includes('All Airframes')) {
-    airframesList.unshift('All Airframes');
-}
-const gfdIndex = airframesList.indexOf('Garmin Flight Display');
-if (gfdIndex !== -1) airframesList.splice(gfdIndex, 1);
+const allAirframes: AirframeNameID = { name: "All Airframes", id: -1 };
+const airframesList = (typeof airframes !== 'undefined' && Array.isArray(airframes))
+    ? airframes.filter(({ name }) => name !== "Garmin Flight Display")
+    : [];
+if (!airframesList.some(({ id, name }) => id === -1 || name === "All Airframes"))
+    airframesList.unshift(allAirframes);
 
 // =======================
 // SECTION: Utility Functions
@@ -472,7 +476,6 @@ const HeatMapPage: React.FC = () => {
     // =======================
 
     // UI State
-    const [airframes, setAirframes] = useState<string[]>(airframesList);
     const [eventChecked, setEventChecked] = useState<EventChecked>(() => {
         const checked: EventChecked = {};
         for (const name of allEventNames) checked[name] = false;
@@ -482,6 +485,11 @@ const HeatMapPage: React.FC = () => {
     const date = new Date();
 
     const [airframe, setAirframe] = useState<string>("All Airframes");
+    const [aircraftType, setAircraftType] = useState<AircraftCategory>("all");
+    const visibleAirframes = useMemo(
+        () => airframesForCategory(airframesList, aircraftType),
+        [aircraftType]
+    );
     const [startYear, setStartYear] = useState<number>(date.getFullYear());
     const [startMonth, setStartMonth] = useState<number>(1);
     const [endYear, setEndYear] = useState<number>(date.getFullYear());
@@ -523,7 +531,7 @@ const HeatMapPage: React.FC = () => {
         //Allow Time Header update after any of the dependencies change
         setDatesOrAirframeChanged(true);
         
-    }, [eventChecked, startYear, startMonth, endYear, endMonth, airframe, boxCoords.minLat, boxCoords.maxLat, boxCoords.minLon, boxCoords.maxLon, minSeverity, maxSeverity]);
+    }, [eventChecked, startYear, startMonth, endYear, endMonth, airframe, aircraftType, boxCoords.minLat, boxCoords.maxLat, boxCoords.minLon, boxCoords.maxLon, minSeverity, maxSeverity]);
 
     // Event Statistics State
     const [eventStatistics, setEventStatistics] = useState<EventStatistics>({
@@ -747,7 +755,7 @@ const HeatMapPage: React.FC = () => {
                 </div>
             </div>
         </div>
-    )
+    );
 
     // =======================
     // SECTION: Grid/Heatmap Toggle Management
@@ -2006,6 +2014,13 @@ const HeatMapPage: React.FC = () => {
         console.log('Airframe changing from', airframe, 'to', af);
         setAirframe(af);
     };
+    const handleAircraftTypeChange = (nextAircraftType: AircraftCategory) => {
+        setAircraftType(nextAircraftType);
+        setAirframe("All Airframes");
+        setProximityEventPoints([]);
+        setError(null);
+        clearMapLayers();
+    };
     const handleStartYear = (y: number) => {
         setStartYear(Number(y));
         setDatesChanged(true);
@@ -2031,6 +2046,7 @@ const HeatMapPage: React.FC = () => {
     // 1. Fetch events matching filters (all types)
     const fetchEvents = async (filters: {
         airframe: string;
+        aircraftType: AircraftCategory;
         eventDefinitionIds: number[];
         startDate: string;
         endDate: string;
@@ -2043,6 +2059,7 @@ const HeatMapPage: React.FC = () => {
     }) => {
         let url = `/protected/proximity_events_in_box?`;
         if (filters.airframe) url += `airframe=${encodeURIComponent(filters.airframe)}&`;
+        url += `aircraftType=${encodeURIComponent(filters.aircraftType)}&`;
         url += `event_definition_ids=${filters.eventDefinitionIds.join(",")}&` +
             `start_date=${filters.startDate}&end_date=${filters.endDate}&` +
             `area_min_lat=${filters.minLat}&area_max_lat=${filters.maxLat}&` +
@@ -2105,6 +2122,7 @@ const HeatMapPage: React.FC = () => {
     // Main orchestration: fetch events, then fetch points via batch endpoint (1000 events per batch)
     const processEventsAndPoints = async (filters: {
         airframe: string;
+        aircraftType: AircraftCategory;
         eventDefinitionIds: number[];
         startDate: string;
         endDate: string;
@@ -2267,6 +2285,7 @@ const HeatMapPage: React.FC = () => {
         if (selectedDefinitionIds.length > 0) {
             await processEventsAndPoints({
                 airframe,
+                aircraftType,
                 eventDefinitionIds: selectedDefinitionIds,
                 startDate: `${startYear}-${startMonth.toString().padStart(2, '0')}-01`,
                 endDate: `${endYear}-${endMonth.toString().padStart(2, '0')}-${new Date(endYear, endMonth, 0).getDate()}`,
@@ -2694,8 +2713,11 @@ const HeatMapPage: React.FC = () => {
     const timeHeader = (
         <TimeHeader
             name="Event Heat Map"
-            airframes={airframes}
+            airframes={visibleAirframes.map(({ name }) => name)}
             airframe={airframe}
+            aircraftTypes={AIRCRAFT_CATEGORIES}
+            aircraftType={aircraftType}
+            aircraftTypeChange={handleAircraftTypeChange}
             startYear={startYear}
             startMonth={startMonth}
             endYear={endYear}
@@ -3001,4 +3023,4 @@ const container = document.querySelector("#heat-map-page");
 if (container) {
     const root = createRoot(container);
     root.render(<HeatMapPage />);
-} 
+}

--- a/ngafid-frontend/src/severities.tsx
+++ b/ngafid-frontend/src/severities.tsx
@@ -16,6 +16,11 @@ import Tooltip from "react-bootstrap/Tooltip";
 import "./index.css";
 import type { AirframeNameID } from "./types";
 import { buildEndDate, buildStartDate } from "./summary_page";
+import {
+  AIRCRAFT_CATEGORIES,
+  airframesForCategory,
+  type AircraftCategory,
+} from "./aircraft_type_filter";
 
 const allAirframes = { name: "All Airframes", id: -1 } as AirframeNameID;
 
@@ -49,8 +54,6 @@ type EventCount = {
 type EventSeverityByAirframe = Record<string, EventCount[]>;
 type EventSeverities = Record<string, EventSeverityByAirframe>;
 
-const eventSeverities: EventSeverities = {};
-
 export function SeveritiesPage() {
   const airframesForUI = useMemo(() => {
     //Remove GFD
@@ -76,6 +79,7 @@ export function SeveritiesPage() {
   const date = new Date();
 
     const [airframe, setAirframe] = useState<AirframeNameID>(allAirframes);
+    const [aircraftType, setAircraftType] = useState<AircraftCategory>("all");
     const [tagName, setTagName] = useState("All Tags");
     const [startYear, setStartYear] = useState(date.getFullYear());
     const [startMonth, setStartMonth] = useState(1);
@@ -91,6 +95,15 @@ export function SeveritiesPage() {
     const [isLoading, setIsLoading] = useState(false);
     const [hasQueried, setHasQueried] = useState(false);
     const loadingCountRef = useRef(0);
+
+    const visibleAirframes = useMemo(
+        () => airframesForCategory(airframesForUI, aircraftType),
+        [aircraftType, airframesForUI]
+    );
+    const visibleAirframeNames = useMemo(
+        () => new Set(visibleAirframes.map(({ name }) => name)),
+        [visibleAirframes]
+    );
 
     const setLoading = useCallback((loading: boolean) => {
         if (loading) {
@@ -128,6 +141,9 @@ export function SeveritiesPage() {
                 if (airframeName === "Garmin Flight Display")
                     continue;
 
+                if (!visibleAirframeNames.has(airframeName))
+                    continue;
+
                 if (selectedAirframe !== airframeName && selectedAirframe !== "All Airframes")
                     continue;
 
@@ -136,7 +152,7 @@ export function SeveritiesPage() {
             }
         }
         return false;
-    }, [eventSeveritiesState, eventChecked, airframe.name]);
+    }, [eventSeveritiesState, eventChecked, airframe.name, visibleAirframeNames]);
 
     const showNoEventsMessage = hasQueried
         && !isLoading
@@ -147,31 +163,33 @@ export function SeveritiesPage() {
   //Effect to update datesOrAirframeChanged when dependencies change
   useEffect(() => {
     setDatesOrAirframeChanged(true);
-  }, [startYear, startMonth, endYear, endMonth, tagName]);
+  }, [startYear, startMonth, endYear, endMonth, tagName, aircraftType]);
 
   useEffect(() => {
     displayPlot(airframe.name);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [airframe.name, eventChecked, eventMetaData, eventSeveritiesState]);
+  }, [airframe.name, eventChecked, eventMetaData, eventSeveritiesState, aircraftType]);
 
   const exportCSV = () => {
     const selectedAirframe = airframe;
 
     console.log(`selected airframe: '${selectedAirframe}'`);
-    console.log(eventSeverities);
+    console.log(eventSeveritiesState);
     const fileHeaders =
       "Event Name,Airframe,Flight ID,Start Time,End Time,Start Line,End Line,Severity";
 
     const fileContent = [fileHeaders];
     const uniqueMetaDataNames: string[] = [];
 
-    for (const [eventName, countsMap] of Object.entries(eventSeverities)) {
+    for (const [eventName, countsMap] of Object.entries(eventSeveritiesState)) {
       //Event is unchecked, skip
       if (!eventChecked[eventName]) continue;
 
       for (const [airframeName, counts] of Object.entries(countsMap)) {
         //Airframe is Garmin Flight Display, skip
         if (airframeName === "Garmin Flight Display") continue;
+
+        if (!visibleAirframeNames.has(airframeName)) continue;
 
         //Airframe is not selected, skip
         if (
@@ -289,6 +307,8 @@ export function SeveritiesPage() {
         for (const [airframeName, counts] of Object.entries(countsMap)) {
           //Got GFD, skip
           if (airframeName === "Garmin Flight Display") continue;
+
+          if (!visibleAirframeNames.has(airframeName)) continue;
 
           //Airframe is unselected, skip
           if (
@@ -472,7 +492,7 @@ export function SeveritiesPage() {
         }
       });
     },
-    [eventChecked, eventSeveritiesState]
+    [eventChecked, eventSeveritiesState, visibleAirframeNames]
   );
 
     const fetchAllEventSeverities = useCallback(() => {
@@ -489,6 +509,7 @@ export function SeveritiesPage() {
       endDate: endDate,
       eventNames: JSON.stringify(eventNames),
       tagName: tagName,
+      aircraftType: aircraftType,
     };
 
         $.ajax({
@@ -537,7 +558,7 @@ export function SeveritiesPage() {
 
         });
 
-    }, [startMonth, startYear, endMonth, endYear, tagName, setLoading]);
+    }, [startMonth, startYear, endMonth, endYear, tagName, aircraftType, setLoading]);
 
     const fetchEventSeverities = (eventName:string) => {
 
@@ -551,6 +572,7 @@ export function SeveritiesPage() {
       startDate: startDate,
       endDate: endDate,
       tagName: tagName,
+      aircraftType: aircraftType,
     };
 
         return new Promise(() => {
@@ -574,7 +596,6 @@ export function SeveritiesPage() {
 
                     setEventsEmpty((prev) => ({ ...prev, [eventName]: !hasAnyData }));
                     
-                    eventSeverities[eventName] = hasAnyData ? response : {};
                     setEventSeveritiesState((prev) => ({
                         ...prev,
                         [eventName]: hasAnyData ? response : {}
@@ -647,6 +668,7 @@ export function SeveritiesPage() {
       endDate: endDate,
       eventNames: JSON.stringify(eventNames),
       tagName: tagName,
+      aircraftType: aircraftType,
     };
 
         $.ajax({
@@ -675,12 +697,12 @@ export function SeveritiesPage() {
             }
         });
 
-    }, [airframe.name, displayPlot, startYear, startMonth, endYear, endMonth, tagName, setLoading]);
+    }, [airframe.name, aircraftType, displayPlot, startYear, startMonth, endYear, endMonth, tagName, setLoading]);
 
 
   const airframeChangeFromName = (airframeName: string) => {
     //Find airframe data in list corresponding to the name
-    const airframe = airframes.find((a) => a.name === airframeName);
+    const airframe = visibleAirframes.find((a) => a.name === airframeName);
 
     //Got an airframe from the name, change the state
     if (airframe) airframeChange(airframe);
@@ -692,6 +714,11 @@ export function SeveritiesPage() {
 
   const tagNameChange = (tagName: string) => {
     setTagName(tagName);
+  };
+
+  const aircraftTypeChange = (nextAircraftType: AircraftCategory) => {
+    setAircraftType(nextAircraftType);
+    setAirframe(allAirframes);
   };
 
   const render = () => {
@@ -727,8 +754,11 @@ export function SeveritiesPage() {
                             <div className="card mb-2 m-2">
                                 <TimeHeader
                                     name="Event Severities"
-                                    airframes={airframesForUI.map(a => a.name)}
+                                    airframes={visibleAirframes.map(a => a.name)}
                                     airframe={airframe.name}
+                                    aircraftTypes={AIRCRAFT_CATEGORIES}
+                                    aircraftType={aircraftType}
+                                    aircraftTypeChange={aircraftTypeChange}
                                     startYear={startYear}
                                     startMonth={startMonth}
                                     endYear={endYear}

--- a/ngafid-frontend/src/summary_page.tsx
+++ b/ngafid-frontend/src/summary_page.tsx
@@ -15,6 +15,11 @@ import "./index.css";
 import * as $ from "jquery";
 import type JQuery from "jquery";
 import type { AirframeNameID } from "./types";
+import {
+    AIRCRAFT_CATEGORIES,
+    airframesForCategory,
+    type AircraftCategory,
+} from "./aircraft_type_filter";
 
 
 const ALL_AIRFRAMES_PAIR = {
@@ -158,7 +163,8 @@ async function fetchStatistic<ResponseType>(
     stat: string,
     route: string,
     aggregate: boolean,
-    airframe: AirframeNameID = ALL_AIRFRAMES_PAIR,
+    airframe: AirframeNameID,
+    aircraftType: AircraftCategory,
     startYear: number,
     startMonth: number,
     endYear: number,
@@ -184,7 +190,8 @@ async function fetchStatistic<ResponseType>(
     const submissionData = {
         startDate: startDate,
         endDate: endDate,
-        airframeID: airframe.id
+        airframeID: airframe.id,
+        aircraftType,
     };
 
 
@@ -357,6 +364,7 @@ type FlightHoursByAirframe = {
 
 type SummaryPageState = {
     airframe: AirframeNameID;
+    aircraftType: AircraftCategory;
     datesOrAirframeChanged: boolean;
     statistics: {
         flightTime: number;
@@ -390,11 +398,14 @@ export type SummaryPageProps = {
 };
 
 export default class SummaryPage extends React.Component<SummaryPageProps, SummaryPageState> {
+    private statisticsRequestId = 0;
+
     constructor(props: SummaryPageProps) {
         super(props);
 
         this.state = {
             airframe: airframes[0],
+            aircraftType: "all",
             datesOrAirframeChanged: false,
             statistics: {
                 ...Object.keys(targetValues).reduce((o, key) => ({...o, [key]: ""}), {}),
@@ -677,6 +688,14 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
         this.setState({airframe, datesOrAirframeChanged: true});
     }
 
+    aircraftTypeChange(aircraftType: AircraftCategory) {
+        this.setState({
+            aircraftType,
+            airframe: ALL_AIRFRAMES_PAIR,
+            datesOrAirframeChanged: false,
+        }, () => this.dateChange());
+    }
+
     dateChange() {
 
         $("#loading").show();
@@ -709,7 +728,8 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
 
         const submissionData = {
             startDate: startDate,
-            endDate: endDate
+            endDate: endDate,
+            aircraftType: this.state.aircraftType,
         };
 
         const route = `/api/event/count/by-airframe${this.props.aggregate ? "/aggregate" : ""}`;
@@ -746,10 +766,14 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
     async fetchStatistics() {
 
         console.log("SummaryPage -- Fetching Statistics...");
+        const requestId = ++this.statisticsRequestId;
 
         for await (const [stat, route] of Object.entries(targetValues)) {
 
             const successResponseHandler = (response: { err_msg?: string; err_title?: string; } | number | string) => {
+
+                if (requestId !== this.statisticsRequestId)
+                    return;
 
                 console.log("Got response for statistic: ", stat, response);
 
@@ -771,6 +795,7 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
                 route,
                 this.props.aggregate,
                 this.state.airframe,
+                this.state.aircraftType,
                 startYear,
                 startMonth,
                 endYear,
@@ -785,11 +810,15 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
             "/api/upload/outcomes",
             this.props.aggregate,
             this.state.airframe,
+            this.state.aircraftType,
             startYear,
             startMonth,
             endYear,
             endMonth,
             response => {
+                if (requestId !== this.statisticsRequestId)
+                    return;
+
                 const uploadCount = Number(response.uploadCount);
                 const okUploadCount = Number(response.okUploadCount);
                 const warningUploadCount = Number(response.warningUploadCount);
@@ -825,7 +854,8 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
         const submissionData = {
             startDate: startDate,
             endDate: endDate,
-            airframeID: this.state.airframe.id
+            airframeID: this.state.airframe.id,
+            aircraftType: this.state.aircraftType,
         };
 
         $.ajax({
@@ -877,7 +907,8 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
         const submissionData = {
             startDate: startDate,
             endDate: endDate,
-            airframeID: this.state.airframe.id
+            airframeID: this.state.airframe.id,
+            aircraftType: this.state.aircraftType,
         };
 
         $.ajax({
@@ -1185,6 +1216,35 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
 
                         </tbody>
                     </table>
+                </div>
+            </div>
+        );
+    }
+
+    FilteredFlightImportsSummary() {
+        const flightCount = this.state.statistics.importedFlights;
+        const selectedType = AIRCRAFT_CATEGORIES.find(option => option.value === this.state.aircraftType)?.label;
+        const selectedScope = this.state.airframe.id >= 0 ? this.state.airframe.name : selectedType;
+        const importLabel = flightCount === 1 ? "Successful Flight Import" : "Successful Flight Imports";
+
+        return (
+            <div className="card flex flex-col h-full flex-1">
+                <h4 className="card-header">Uploads</h4>
+                <div className="card-body px-12! flex flex-col justify-center">
+                    <div>
+                        <span
+                            className="badge"
+                            style={{backgroundColor: "var(--c_valid)", color: "white"}}
+                        >
+                            <i className="fa fa-fw fa-check" aria-hidden="true"/>
+                            &nbsp;{formatNumberAsync(flightCount, integerOptions)}
+                        </span>
+                        <span>&nbsp;{importLabel}</span>
+                    </div>
+                    <p className="text-muted mt-3 mb-0">
+                        Pending and failed upload totals are not shown for {selectedScope} because those uploads may
+                        not have aircraft metadata yet.
+                    </p>
                 </div>
             </div>
         );
@@ -1523,8 +1583,12 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
                 <TimeHeader
                     className="rounded-lg! bg-(--c_card_header_bg_opaque)! border-(--c_border_alt)! border-1!"
                     name={`Event Statistics Summary ${this.props.aggregate ? "(Aggregate)" : ""}`}
-                    airframes={airframes.map((airframe: AirframeNameID) => airframe.name)}
+                    airframes={airframesForCategory(airframes, this.state.aircraftType)
+                        .map((airframe: AirframeNameID) => airframe.name)}
                     airframe={this.state.airframe.name}
+                    aircraftTypes={AIRCRAFT_CATEGORIES}
+                    aircraftType={this.state.aircraftType}
+                    aircraftTypeChange={(aircraftType: AircraftCategory) => this.aircraftTypeChange(aircraftType)}
                     startYear={startYear}
                     startMonth={startMonth}
                     endYear={endYear}
@@ -1566,7 +1630,11 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
                             {newSummaryTable}
 
                             {/* Uploads Summary */}
-                            {this.props.aggregate ? this.UploadsSummaryAggregate() : this.UploadsSummary()}
+                            {
+                                this.state.aircraftType === "all" && this.state.airframe.id < 0
+                                    ? (this.props.aggregate ? this.UploadsSummaryAggregate() : this.UploadsSummary())
+                                    : this.FilteredFlightImportsSummary()
+                            }
 
                             {/* Aggregate Flight Hours by Airframe Table */}
                             {

--- a/ngafid-frontend/src/time_header.js
+++ b/ngafid-frontend/src/time_header.js
@@ -69,6 +69,27 @@ export default class TimeHeader extends React.Component {
                 </div>
             );
         }
+        let aircraftType = null;
+        if ('aircraftType' in this.props) {
+            aircraftType = (
+                <div className="flex flex-row items-center gap-2" role="group" aria-label="Aircraft type filter">
+                    <span className="whitespace-nowrap">Aircraft type</span>
+                    <div className="btn-group" role="group">
+                        {this.props.aircraftTypes.map(option => (
+                            <button
+                                key={option.value}
+                                type="button"
+                                className={`btn ${this.props.aircraftType === option.value ? 'btn-primary' : 'btn-secondary-outline'}`}
+                                aria-pressed={this.props.aircraftType === option.value}
+                                onClick={() => this.props.aircraftTypeChange(option.value)}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            );
+        }
         let tags = null;
         if ('tagName' in this.props) {
             tags = (
@@ -111,13 +132,16 @@ export default class TimeHeader extends React.Component {
         })();
 
         return (
-            <div className="flex flex-row items-center justify-start gap-4" style={{ textAlign: 'center' }}>
+            <div className="flex flex-row flex-wrap items-center justify-start gap-4" style={{ textAlign: 'center' }}>
 
                 {/* Export Button */}
                 {exportButton}
 
                 {/* Tags */}
                 {tags}
+
+                {/* Aircraft type */}
+                {aircraftType}
 
                 {/* Airframe Drop-down */}
                 {airframe}

--- a/ngafid-frontend/src/trends.tsx
+++ b/ngafid-frontend/src/trends.tsx
@@ -12,6 +12,12 @@ import Plotly from 'plotly.js';
 import Tooltip from "react-bootstrap/Tooltip";
 import { OverlayTrigger } from "react-bootstrap";
 import type { AirframeNameID } from "./types";
+import {
+    AIRCRAFT_CATEGORIES,
+    airframesForCategory,
+    aircraftTypeMatchesCategory,
+    type AircraftCategory,
+} from "./aircraft_type_filter";
 
 
 const allAirframes = { name: "All Airframes", id: -1 } as AirframeNameID;
@@ -107,6 +113,7 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
     // const [eventFleetPercents, setEventFleetPercents] = useState<{ [key: string]: CountsData }>({});
     // const [eventNGAFIDPercents, setEventNGAFIDPercents] = useState<{ [key: string]: CountsData }>({});
     const [airframe, setAirframe] = useState<AirframeNameID>(allAirframes);
+    const [aircraftType, setAircraftType] = useState<AircraftCategory>("all");
     const [startYear, setStartYear] = useState<number>(date.getFullYear());
     const [startMonth, setStartMonth] = useState<number>(1);
     const [endYear, setEndYear] = useState<number>(date.getFullYear());
@@ -269,6 +276,11 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
         const airframeNames: string[] = [];
         const dates: string[] = [];
         const csvValues: CSVValues = {};
+        const visibleAirframeNames = new Set(
+            Object.entries(aircraftTypesByName)
+                .filter(([, type]) => aircraftTypeMatchesCategory(type, aircraftType))
+                .map(([name]) => name)
+        );
 
         for (const [eventName, countsObject] of Object.entries(eventCounts)) {
 
@@ -284,6 +296,9 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
 
                 //Airframe is Garmin Flight Display, skip
                 if (airframe.name === "Garmin Flight Display")
+                    continue;
+
+                if (!visibleAirframeNames.has(value.airframeName))
                     continue;
 
                 //Airframe is not selected, skip
@@ -469,7 +484,14 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
         const ngafidAgg: Record<string, Aggregator> = {};  // eventName -> all fleets / other fleets
 
         const counts = eventCounts ?? {};
-        const fleetAirframeNames = new Set(airframes.map(a => a.name));
+        const visibleAirframeNames = new Set(
+            Object.entries(aircraftTypesByName)
+                .filter(([, type]) => aircraftTypeMatchesCategory(type, aircraftType))
+                .map(([name]) => name)
+        );
+        const fleetAirframeNames = new Set(
+            airframesForCategory(airframes, aircraftType).map(item => item.name)
+        );
 
         //Build count traces, fill aggregators for percent data
         for (const [eventName, countsObject] of Object.entries(counts)) {
@@ -519,6 +541,9 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
 
                 //Got skippable airframe, skip
                 if (AIRFRAME_NAMES_SKIP.includes(value.airframeName))
+                    continue;
+
+                if (!visibleAirframeNames.has(value.airframeName))
                     continue;
 
                 //Current airframe isn't selected, skip
@@ -582,7 +607,7 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
             for (const v of Object.values(countsObject as { [k: string]: TrendsData })) {
 
                 //Airframe not in airframe names list, add it
-                if (!airframeNames.includes(v.airframeName))
+                if (visibleAirframeNames.has(v.airframeName) && !airframeNames.includes(v.airframeName))
                     airframeNames.push(v.airframeName);
 
             }
@@ -699,7 +724,7 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
 
         $('#loading').hide();
 
-    }, [eventCounts, eventChecked, aggregatePage]);
+    }, [eventCounts, eventChecked, aggregatePage, aircraftType]);
 
 
 
@@ -707,7 +732,7 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
         displayPlots(airframe.name);
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [airframe.name, eventCounts, eventChecked, aggregatePage]);
+    }, [airframe.name, eventCounts, eventChecked, aggregatePage, aircraftType]);
 
     const checkEvent = (eventName: string) => {
 
@@ -811,6 +836,12 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
         setAirframe(airframe);
     };
 
+    const aircraftTypeChange = (category: AircraftCategory) => {
+        setAircraftType(category);
+        setAirframe(allAirframes);
+        setDatesOrAirframeChanged(true);
+    };
+
     const render = () => {
 
         const activePageName = (aggregatePage ? "aggregate_trends" : "trends");
@@ -837,8 +868,12 @@ export function TrendsPage({ aggregate_page }: TrendsPageProps) {
                             <div className="card m-2">
                                 <TimeHeader
                                     name={timeHeaderTitle}
-                                    airframes={airframes.map((airframe: AirframeNameID) => airframe.name)}
+                                    airframes={airframesForCategory(airframes, aircraftType)
+                                        .map((airframe: AirframeNameID) => airframe.name)}
                                     airframe={airframe.name}
+                                    aircraftTypes={AIRCRAFT_CATEGORIES}
+                                    aircraftType={aircraftType}
+                                    aircraftTypeChange={aircraftTypeChange}
                                     startYear={startYear}
                                     startMonth={startMonth}
                                     endYear={endYear}

--- a/ngafid-frontend/src/ttf.js
+++ b/ngafid-frontend/src/ttf.js
@@ -10,6 +10,7 @@ import { closer, container, initializeMap, layers, map, overlay, styles } from "
 import { paletteGenerator } from "./map_utils.js";
 import SignedInNavbar from "./signed_in_navbar.js";
 import { TimeHeader, TurnToFinalHeaderComponents } from "./time_header.js";
+import { AIRCRAFT_CATEGORIES } from "./aircraft_type_filter";
 
 import Feature from 'ol/Feature.js';
 import LineString from 'ol/geom/LineString.js';
@@ -299,6 +300,7 @@ class TTFCard extends React.Component {
             // The end of the date range that this.state.data corresponds to.
             // This will be null if and only if this.state.data is null
             dataEndDate: null,
+            dataAircraftType: null,
 
             // Data is an object containing the following information:
             //     data = {
@@ -309,6 +311,7 @@ class TTFCard extends React.Component {
             data: null,
 
             datesChanged: true,
+            aircraftType: "all",
 
             minRoll: ROLL_THRESHOLDS.Default,
 
@@ -511,6 +514,9 @@ class TTFCard extends React.Component {
     }
 
     fetchFlightLookupForMissingIds(startDate, endDate, airportIataCode) {
+        const selectedAircraftType = AIRCRAFT_CATEGORIES.find(
+            ({ value }) => value === this.state.aircraftType
+        );
         const overlapFilter = {
             type: 'GROUP',
             condition: 'OR',
@@ -539,6 +545,9 @@ class TTFCard extends React.Component {
             condition: 'AND',
             filters: [
                 { type: 'RULE', inputs: ['Airport', airportIataCode, 'visited'] },
+                ...(selectedAircraftType && selectedAircraftType.value !== 'all'
+                    ? [{ type: 'RULE', inputs: ['Aircraft Type', 'is', selectedAircraftType.label] }]
+                    : []),
                 overlapFilter
             ]
         };
@@ -1077,6 +1086,7 @@ class TTFCard extends React.Component {
             startDate: startDateString,
             endDate: endDateString,
             airport: airport,
+            aircraftType: this.state.aircraftType,
         };
 
         const startDate = this.parseDate(startDateString);
@@ -1195,6 +1205,7 @@ class TTFCard extends React.Component {
                             dataAirport: submissionData.airport,
                             dataStartDate: submissionData.startDate,
                             dataEndDate: submissionData.endDate,
+                            dataAircraftType: submissionData.aircraftType,
                             data: { ttfs: accumulatedTtfs, airports: accumulatedAirports }
                         });
                     }
@@ -1224,7 +1235,8 @@ class TTFCard extends React.Component {
             this.state.data != null
             && this.dateWithinRange(startDate, dataStartDate, dataEndDate)
             && this.dateWithinRange(endDate, dataStartDate, dataEndDate)
-            && airport == this.state.dataAirport) {
+            && airport == this.state.dataAirport
+            && this.state.aircraftType === this.state.dataAircraftType) {
 
             for (const ttf of this.state.data.ttfs) {
                 ttf.enabled = true;
@@ -1309,6 +1321,7 @@ class TTFCard extends React.Component {
                                     dataAirport: submissionData.airport,
                                     dataStartDate: submissionData.startDate,
                                     dataEndDate: submissionData.endDate,
+                                    dataAircraftType: submissionData.aircraftType,
                                     data: { ttfs: accumulatedTtfs, airports: accumulatedAirports }
                                 });
                             }
@@ -1338,6 +1351,10 @@ class TTFCard extends React.Component {
     onAirportFilterChanged(airport) {
         const iataCode = airport;
         this.setState({ selectedAirport: iataCode, selectedRunway: "Any Runway", datesChanged: true, });
+    }
+
+    onAircraftTypeChanged(aircraftType) {
+        this.setState({ aircraftType, datesChanged: true });
     }
 
     onUpdateStartYear(year) {
@@ -1584,6 +1601,9 @@ class TTFCard extends React.Component {
                     buttonContent={'Fetch'}
                     extraHeaderComponents={turnToFinalHeaderComponents}
                     extraRowComponents={rollSlider}
+                    aircraftTypes={AIRCRAFT_CATEGORIES}
+                    aircraftType={this.state.aircraftType}
+                    aircraftTypeChange={(aircraftType) => this.onAircraftTypeChanged(aircraftType)}
                     startYear={this.state.startYear}
                     startMonth={this.state.startMonth}
                     endYear={this.state.endYear}

--- a/ngafid-frontend/src/types.d.ts
+++ b/ngafid-frontend/src/types.d.ts
@@ -58,6 +58,7 @@ export type MultifleetSelectWithAccess = {
 export interface AirframeNameID {
     name: string;
     id: number;
+    type?: string;
 }
 declare global {
     const waitingUserCount: number;
@@ -66,6 +67,7 @@ declare global {
     const modifyTailsAccess: boolean;
     const plotMapHidden: boolean;
     const airframes: AirframeNameID[];
+    const aircraftTypesByName: { [airframeName: string]: string };
     const tagNames: string[];
     const eventNames: string[];
 }

--- a/ngafid-www/src/main/java/org/ngafid/www/EventStatistics.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/EventStatistics.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.ngafid.core.event.EventDefinition;
 import org.ngafid.core.flights.Airframes;
+import org.ngafid.core.flights.Airframes.AircraftCategory;
 import org.ngafid.core.util.TimeUtils;
 import org.ngafid.www.flights.FlightStatistics;
 
@@ -503,6 +504,18 @@ public class EventStatistics {
 
             throw new SQLException("Failed to read from table " + tableName + ":" + statement);
         }
+    }
+
+    public static int getEventCountByAircraftCategory(
+            Connection connection,
+            Integer fleetId,
+            LocalDate startDate,
+            LocalDate endDate,
+            AircraftCategory category)
+            throws SQLException {
+        String condition = buildDateClause(startDate, endDate) + " AND " + category.sqlCondition("airframe_id");
+        if (fleetId != null) condition = "fleet_id = " + fleetId + " AND " + condition;
+        return getEventCount(connection, "m_fleet_airframe_monthly_event_counts", condition);
     }
 
     /**

--- a/ngafid-www/src/main/java/org/ngafid/www/flights/FlightStatistics.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/flights/FlightStatistics.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.logging.Logger;
 import org.ngafid.core.util.TimeUtils;
+import org.ngafid.core.flights.Airframes.AircraftCategory;
 
 public enum FlightStatistics {
     ;
@@ -166,6 +167,44 @@ public enum FlightStatistics {
                 return 0;
             }
         }
+    }
+
+    public static double getFlightTimeByAircraftCategory(
+            Connection connection,
+            Integer fleetId,
+            LocalDate startDate,
+            LocalDate endDate,
+            AircraftCategory category)
+            throws SQLException {
+        String condition = buildDateClause(startDate, endDate) + " AND " + category.sqlCondition("airframe_id");
+        if (fleetId != null) condition = "fleet_id = " + fleetId + " AND " + condition;
+        return getFlightTimeImpl(connection, "m_fleet_monthly_flight_time", condition);
+    }
+
+    public static int getFlightCountByAircraftCategory(
+            Connection connection,
+            Integer fleetId,
+            LocalDate startDate,
+            LocalDate endDate,
+            AircraftCategory category)
+            throws SQLException {
+        String condition = buildDateClause(startDate, endDate) + " AND " + category.sqlCondition("airframe_id");
+        if (fleetId != null) condition = "fleet_id = " + fleetId + " AND " + condition;
+        return getFlightCountImpl(connection, "m_fleet_monthly_flight_counts", condition);
+    }
+
+    public static double get30DayFlightTimeByAircraftCategory(
+            Connection connection, Integer fleetId, AircraftCategory category) throws SQLException {
+        String condition = category.sqlCondition("airframe_id");
+        if (fleetId != null) condition = "fleet_id = " + fleetId + " AND " + condition;
+        return getFlightTimeImpl(connection, "m_fleet_30_day_flight_time", condition);
+    }
+
+    public static int get30DayFlightCountByAircraftCategory(
+            Connection connection, Integer fleetId, AircraftCategory category) throws SQLException {
+        String condition = category.sqlCondition("airframe_id");
+        if (fleetId != null) condition = "fleet_id = " + fleetId + " AND " + condition;
+        return getFlightCountImpl(connection, "m_fleet_30_day_flight_counts", condition);
     }
 
     public static int getTotalFlightCount(Connection connection, int fleetId, int airframeId) throws SQLException {

--- a/ngafid-www/src/main/java/org/ngafid/www/routes/AnalysisJavalinRoutes.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/routes/AnalysisJavalinRoutes.java
@@ -310,7 +310,7 @@ public class AnalysisJavalinRoutes {
         try (Connection connection = Database.getConnection()) {
             Map<String, Object> scopes = new HashMap<>();
 
-            final Airframes.AirframeNameID[] airframes = Airframes.getAllWithIds(connection, fleetId);
+            final Airframes.TypedAirframeNameID[] airframes = Airframes.getAllWithIdsAndTypes(connection, fleetId);
             final String fleetInfo = "var airframes = " + GSON.toJson(airframes) + ";\n" + "var eventNames = "
                     + GSON.toJson(EventDefinition.getUniqueNames(connection, fleetId)) + ";\n" + "var tagNames = "
                     + GSON.toJson(Flight.getAllFleetTagNames(connection, fleetId)) + ";\n";
@@ -351,9 +351,18 @@ public class AnalysisJavalinRoutes {
     }
 
     public static void postTurnToFinal(Context ctx) {
+        final User user = Objects.requireNonNull(ctx.sessionAttribute("user"));
+        final int fleetId = user.getFleetId();
+        if (!user.hasViewAccess(fleetId)) {
+            ctx.status(401).result("User did not have access to view flights for this fleet.");
+            return;
+        }
+
         String startDate = ctx.queryParam("startDate");
         String endDate = ctx.queryParam("endDate");
         String airportIataCode = ctx.queryParam("airport");
+        Airframes.AircraftCategory aircraftCategory =
+                Airframes.AircraftCategory.fromQueryValue(ctx.queryParam("aircraftType"));
         int limit = parseIntOrDefault(ctx.queryParam("limit"), 1000);
         int offset = parseIntOrDefault(ctx.queryParam("offset"), 0);
         boolean skipCount = "true".equalsIgnoreCase(ctx.queryParam("skipCount"));
@@ -365,13 +374,13 @@ public class AnalysisJavalinRoutes {
         try (Connection connection = Database.getConnection()) {
             if (offset == 0 && !skipCount) {
                 totalFlights = Flight.getFlightsCountWithinDateRangeFromAirport(
-                        connection, startDate, endDate, airportIataCode);
+                        connection, startDate, endDate, airportIataCode, fleetId, aircraftCategory);
             }
 
             List<Integer> flightIds = (offset == 0 && !skipCount && totalFlights == 0)
                     ? List.of()
                     : Flight.getFlightIdsWithinDateRangeFromAirport(
-                            connection, startDate, endDate, airportIataCode, limit, offset);
+                            connection, startDate, endDate, airportIataCode, limit, offset, fleetId, aircraftCategory);
 
             Map<Integer, ArrayList<TurnToFinal>> batchResult =
                     TurnToFinal.getTurnToFinalBatchByFlightIds(connection, flightIds, airportIataCode);
@@ -422,10 +431,15 @@ public class AnalysisJavalinRoutes {
         try (Connection connection = Database.getConnection()) {
             Map<String, Object> scopes = new HashMap<>();
 
-            Airframes.AirframeNameID[] airframes = Airframes.getAllWithIds(connection, fleetId);
+            Airframes.TypedAirframeNameID[] airframes = Airframes.getAllWithIdsAndTypes(connection, fleetId);
+            Map<String, String> aircraftTypesByName = new HashMap<>();
+            for (Airframes.TypedAirframeNameID item : Airframes.getAllWithIdsAndTypes(connection)) {
+                aircraftTypesByName.put(item.name(), item.type());
+            }
             final String fleetInfo = "var airframes = " + GSON.toJson(airframes) + ";\n" + "var eventNames = "
                     + GSON.toJson(EventDefinition.getUniqueNames(connection, fleetId)) + ";\n" + "var tagNames = "
-                    + GSON.toJson(Flight.getAllTagNames(connection)) + ";\n";
+                    + GSON.toJson(Flight.getAllTagNames(connection)) + ";\n" + "var aircraftTypesByName = "
+                    + GSON.toJson(aircraftTypesByName) + ";\n";
 
             scopes.put("navbar_js", Navbar.getJavascript(ctx));
             scopes.put("fleet_info_js", fleetInfo);
@@ -446,7 +460,7 @@ public class AnalysisJavalinRoutes {
         // Inject airframes variable for frontend
         try (Connection connection = Database.getConnection()) {
             int fleetId = user.getFleetId();
-            java.util.List<String> airframes = Airframes.getAll(connection, fleetId);
+            Airframes.TypedAirframeNameID[] airframes = Airframes.getAllWithIdsAndTypes(connection, fleetId);
             com.google.gson.Gson gson = new com.google.gson.Gson();
             scopes.put("fleet_info_js", "var airframes = " + gson.toJson(airframes) + ";\n");
         } catch (Exception e) {
@@ -607,6 +621,8 @@ public class AnalysisJavalinRoutes {
             return;
         }
         String airframe = ctx.queryParam("airframe");
+        Airframes.AircraftCategory aircraftCategory =
+                Airframes.AircraftCategory.fromQueryValue(ctx.queryParam("aircraftType"));
         String eventDefinitionIdsParam = ctx.queryParam("event_definition_ids");
         String startDate = ctx.queryParam("start_date");
         String endDate = ctx.queryParam("end_date");
@@ -637,6 +653,7 @@ public class AnalysisJavalinRoutes {
             List<java.util.Map<String, Object>> events = org.ngafid.core.heatmap.HeatmapPointsProcessor.getEvents(
                     fleetId,
                     airframe,
+                    aircraftCategory,
                     eventDefinitionIds,
                     java.sql.Date.valueOf(startDate),
                     java.sql.Date.valueOf(endDate),

--- a/ngafid-www/src/main/java/org/ngafid/www/routes/StartPageJavalinRoutes.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/routes/StartPageJavalinRoutes.java
@@ -71,7 +71,7 @@ public class StartPageJavalinRoutes {
 
         try (Connection connection = Database.getConnection()) {
             Map<String, Object> scopes = new HashMap<>();
-            Airframes.AirframeNameID[] airframes = Airframes.getAllWithIds(connection, fleetId);
+            Airframes.TypedAirframeNameID[] airframes = Airframes.getAllWithIdsAndTypes(connection, fleetId);
 
             scopes.put("navbar_js", Navbar.getJavascript(ctx));
             scopes.put("fleet_info_js", "var airframes = " + GSON.toJson(airframes) + ";\n");

--- a/ngafid-www/src/main/java/org/ngafid/www/routes/StatisticsJavalinRoutes.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/routes/StatisticsJavalinRoutes.java
@@ -16,8 +16,10 @@ import org.ngafid.core.accounts.Fleet;
 import org.ngafid.core.accounts.User;
 import org.ngafid.core.event.EventDefinition;
 import org.ngafid.core.flights.Airframes;
+import org.ngafid.core.flights.Airframes.AircraftCategory;
 import org.ngafid.core.flights.Flight;
 import org.ngafid.core.flights.Tails;
+import org.ngafid.core.util.TimeUtils;
 import org.ngafid.www.ErrorResponse;
 import org.ngafid.www.EventStatistics;
 import org.ngafid.www.Navbar;
@@ -78,6 +80,19 @@ public class StatisticsJavalinRoutes {
             return this.fleetId <= 0;
         }
 
+        private AircraftCategory aircraftCategory() {
+            return AircraftCategory.fromQueryValue(context.queryParam("aircraftType"));
+        }
+
+        private Integer selectedFleetId() {
+            return aggregate() ? null : fleetId;
+        }
+
+        private int selectedAirframeId() {
+            final String airframeId = context.queryParam("airframeID");
+            return airframeId != null ? Integer.parseInt(airframeId) : -1;
+        }
+
         public Double flightTime() throws SQLException {
 
             final String startDateIn = context.queryParam("startDate");
@@ -86,8 +101,12 @@ public class StatisticsJavalinRoutes {
             final LocalDate startDate = startDateIn != null ? LocalDate.parse(startDateIn) : LocalDate.MIN;
             final LocalDate endDate = endDateIn != null ? LocalDate.parse(endDateIn) : LocalDate.MAX;
 
-            final String airframeIDParam = context.queryParam("airframeID");
-            final int airframeID = airframeIDParam != null ? Integer.parseInt(airframeIDParam) : -1;
+            final int airframeID = selectedAirframeId();
+
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                return FlightStatistics.getFlightTimeByAircraftCategory(
+                        connection, selectedFleetId(), startDate, endDate, aircraftCategory());
+            }
 
             if (aggregate())
                 return FlightStatistics.getAggregateTotalFlightTimeDated(connection, startDate, endDate, airframeID);
@@ -95,18 +114,33 @@ public class StatisticsJavalinRoutes {
         }
 
         public Double yearFlightTime() throws SQLException {
+            final int airframeID = selectedAirframeId();
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                int year = TimeUtils.getCurrentYearUTC();
+                return FlightStatistics.getFlightTimeByAircraftCategory(
+                        connection,
+                        selectedFleetId(),
+                        LocalDate.of(year, 1, 1),
+                        LocalDate.of(year, 12, 31),
+                        aircraftCategory());
+            }
             if (aggregate()) {
-                return FlightStatistics.getAggregateCurrentYearFlightTime(connection, 0);
+                return FlightStatistics.getAggregateCurrentYearFlightTime(connection, airframeID);
             } else {
-                return FlightStatistics.getCurrentYearFlightTime(connection, fleetId, 0);
+                return FlightStatistics.getCurrentYearFlightTime(connection, fleetId, airframeID);
             }
         }
 
         public Double monthFlightTime() throws SQLException {
-            if (aggregate()) {
-                return FlightStatistics.getAggregate30DayFlightTime(connection, 0);
+            final int airframeID = selectedAirframeId();
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                return FlightStatistics.get30DayFlightTimeByAircraftCategory(
+                        connection, selectedFleetId(), aircraftCategory());
             }
-            return FlightStatistics.get30DayFlightTime(connection, fleetId, 0);
+            if (aggregate()) {
+                return FlightStatistics.getAggregate30DayFlightTime(connection, airframeID);
+            }
+            return FlightStatistics.get30DayFlightTime(connection, fleetId, airframeID);
         }
 
         public Integer numberFlights() throws SQLException {
@@ -117,8 +151,12 @@ public class StatisticsJavalinRoutes {
             final LocalDate startDate = startDateIn != null ? LocalDate.parse(startDateIn) : LocalDate.MIN;
             final LocalDate endDate = endDateIn != null ? LocalDate.parse(endDateIn) : LocalDate.MAX;
 
-            final String airframeIDParam = context.queryParam("airframeID");
-            final int airframeID = airframeIDParam != null ? Integer.parseInt(airframeIDParam) : -1;
+            final int airframeID = selectedAirframeId();
+
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                return FlightStatistics.getFlightCountByAircraftCategory(
+                        connection, selectedFleetId(), startDate, endDate, aircraftCategory());
+            }
 
             if (aggregate())
                 return FlightStatistics.getAggregateTotalFlightCountDated(connection, startDate, endDate, airframeID);
@@ -126,22 +164,37 @@ public class StatisticsJavalinRoutes {
         }
 
         public Integer numberAircraft() throws SQLException {
-            return Tails.getNumberTails(connection, fleetId);
+            return Tails.getNumberTails(connection, fleetId, aircraftCategory(), selectedAirframeId());
         }
 
         public Integer yearNumberFlights() throws SQLException {
+            final int airframeID = selectedAirframeId();
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                int year = TimeUtils.getCurrentYearUTC();
+                return FlightStatistics.getFlightCountByAircraftCategory(
+                        connection,
+                        selectedFleetId(),
+                        LocalDate.of(year, 1, 1),
+                        LocalDate.of(year, 12, 31),
+                        aircraftCategory());
+            }
             if (aggregate()) {
-                return FlightStatistics.getAggregateCurrentYearFlightCount(connection, 0);
+                return FlightStatistics.getAggregateCurrentYearFlightCount(connection, airframeID);
             } else {
-                return FlightStatistics.getCurrentYearFlightCount(connection, fleetId, 0);
+                return FlightStatistics.getCurrentYearFlightCount(connection, fleetId, airframeID);
             }
         }
 
         public Integer monthNumberFlights() throws SQLException {
+            final int airframeID = selectedAirframeId();
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                return FlightStatistics.get30DayFlightCountByAircraftCategory(
+                        connection, selectedFleetId(), aircraftCategory());
+            }
             if (aggregate()) {
-                return FlightStatistics.getAggregate30DayFlightCount(connection, 0);
+                return FlightStatistics.getAggregate30DayFlightCount(connection, airframeID);
             } else {
-                return FlightStatistics.get30DayFlightCount(connection, fleetId, 0);
+                return FlightStatistics.get30DayFlightCount(connection, fleetId, airframeID);
             }
         }
 
@@ -153,8 +206,12 @@ public class StatisticsJavalinRoutes {
             final LocalDate startDate = startDateIn != null ? LocalDate.parse(startDateIn) : LocalDate.MIN;
             final LocalDate endDate = endDateIn != null ? LocalDate.parse(endDateIn) : LocalDate.MAX;
 
-            final String airframeIDParam = context.queryParam("airframeID");
-            final int airframeID = airframeIDParam != null ? Integer.parseInt(airframeIDParam) : -1;
+            final int airframeID = selectedAirframeId();
+
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                return EventStatistics.getEventCountByAircraftCategory(
+                        connection, selectedFleetId(), startDate, endDate, aircraftCategory());
+            }
 
             if (aggregate())
                 return EventStatistics.getAggregateTotalEventCountDated(connection, startDate, endDate, airframeID);
@@ -162,18 +219,45 @@ public class StatisticsJavalinRoutes {
         }
 
         public Integer yearEvents() throws SQLException {
+            final int airframeID = selectedAirframeId();
+            int year = TimeUtils.getCurrentYearUTC();
+            LocalDate firstDay = LocalDate.of(year, 1, 1);
+            LocalDate lastDay = LocalDate.of(year, 12, 31);
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                return EventStatistics.getEventCountByAircraftCategory(
+                        connection, selectedFleetId(), firstDay, lastDay, aircraftCategory());
+            }
+            if (airframeID < 0) {
+                return aggregate()
+                        ? EventStatistics.getAggregateCurrentYearEventCount(connection)
+                        : EventStatistics.getCurrentYearEventCount(connection, fleetId);
+            }
             if (aggregate()) {
-                return EventStatistics.getAggregateCurrentYearEventCount(connection);
+                return EventStatistics.getAggregateTotalEventCountDated(connection, firstDay, lastDay, airframeID);
             } else {
-                return EventStatistics.getCurrentYearEventCount(connection, fleetId);
+                return EventStatistics.getTotalEventCountDated(connection, fleetId, firstDay, lastDay, airframeID);
             }
         }
 
         public Integer monthEvents() throws SQLException {
+            final int airframeID = selectedAirframeId();
+            int year = TimeUtils.getCurrentYearUTC();
+            int month = TimeUtils.getCurrentMonthUTC();
+            LocalDate firstDay = LocalDate.of(year, month, 1);
+            LocalDate lastDay = firstDay.withDayOfMonth(firstDay.lengthOfMonth());
+            if (airframeID < 0 && aircraftCategory() != AircraftCategory.ALL) {
+                return EventStatistics.getEventCountByAircraftCategory(connection, selectedFleetId(), firstDay,
+                        lastDay, aircraftCategory());
+            }
+            if (airframeID < 0) {
+                return aggregate()
+                        ? EventStatistics.getAggregateCurrentMonthEventCount(connection)
+                        : EventStatistics.getCurrentMonthEventCount(connection, fleetId);
+            }
             if (aggregate()) {
-                return EventStatistics.getAggregateCurrentMonthEventCount(connection);
+                return EventStatistics.getAggregateTotalEventCountDated(connection, firstDay, lastDay, airframeID);
             } else {
-                return EventStatistics.getCurrentMonthEventCount(connection, fleetId);
+                return EventStatistics.getTotalEventCountDated(connection, fleetId, firstDay, lastDay, airframeID);
             }
         }
 
@@ -227,6 +311,14 @@ public class StatisticsJavalinRoutes {
 
             final LocalDate startDate = startDateIn != null ? LocalDate.parse(startDateIn) : LocalDate.MIN;
             final LocalDate endDate = endDateIn != null ? LocalDate.parse(endDateIn) : LocalDate.MAX;
+
+            final int airframeId = selectedAirframeId();
+            final AircraftCategory category = aircraftCategory();
+            if (airframeId >= 0 || category != AircraftCategory.ALL) {
+                int successfulFlightCount = UploadStatistics.getSuccessfulFlightCountDated(
+                        connection, aggregate() ? null : fleetId, startDate, endDate, category, airframeId);
+                return new UploadStatistics.UploadOutcomeCounts(0, 0, 0, 0, 0, successfulFlightCount, 0, 0);
+            }
 
             return UploadStatistics.getUploadOutcomeCountsDated(
                     connection, aggregate() ? null : fleetId, startDate, endDate);
@@ -312,7 +404,7 @@ public class StatisticsJavalinRoutes {
 
             long startTime = System.currentTimeMillis();
 
-            Airframes.AirframeNameID[] airframes = Airframes.getAllWithIds(connection);
+            Airframes.TypedAirframeNameID[] airframes = Airframes.getAllWithIdsAndTypes(connection);
             scopes.put("fleet_info_js", "var airframes = " + GSON.toJson(airframes) + ";\n");
             long endTime = System.currentTimeMillis();
 
@@ -351,10 +443,15 @@ public class StatisticsJavalinRoutes {
 
             long startTime = System.currentTimeMillis();
 
-            Airframes.AirframeNameID[] airframes = Airframes.getAllWithIds(connection);
+            Airframes.TypedAirframeNameID[] airframes = Airframes.getAllWithIdsAndTypes(connection);
+            Map<String, String> aircraftTypesByName = new HashMap<>();
+            for (Airframes.TypedAirframeNameID item : airframes) {
+                aircraftTypesByName.put(item.name(), item.type());
+            }
             String fleetInfo = "var airframes = " + GSON.toJson(airframes) + ";\n" + "var eventNames = "
                     + GSON.toJson(EventDefinition.getUniqueNames(connection)) + ";\n" + "var tagNames = "
-                    + GSON.toJson(Flight.getAllTagNames(connection)) + ";\n";
+                    + GSON.toJson(Flight.getAllTagNames(connection)) + ";\n" + "var aircraftTypesByName = "
+                    + GSON.toJson(aircraftTypesByName) + ";\n";
 
             scopes.put("fleet_info_js", fleetInfo);
             long endTime = System.currentTimeMillis();
@@ -403,6 +500,14 @@ public class StatisticsJavalinRoutes {
 
             Map<String, EventStatistics.EventCounts> eventCountsMap = EventStatistics.getEventCounts(
                     connection, fleetId, LocalDate.parse(startDate), LocalDate.parse(endDate));
+            AircraftCategory category = AircraftCategory.fromQueryValue(ctx.queryParam("aircraftType"));
+            if (category != AircraftCategory.ALL) {
+                Map<String, String> typesByName = new HashMap<>();
+                for (Airframes.TypedAirframeNameID airframe : Airframes.getAllWithIdsAndTypes(connection)) {
+                    typesByName.put(airframe.name(), airframe.type());
+                }
+                eventCountsMap.entrySet().removeIf(entry -> !category.matches(typesByName.get(entry.getKey())));
+            }
             ctx.json(eventCountsMap);
         } catch (SQLException e) {
             e.printStackTrace();

--- a/ngafid-www/src/main/java/org/ngafid/www/uploads/UploadStatistics.java
+++ b/ngafid-www/src/main/java/org/ngafid/www/uploads/UploadStatistics.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import org.ngafid.core.flights.Airframes.AircraftCategory;
 
 public enum UploadStatistics {
     ;
@@ -119,6 +120,49 @@ public enum UploadStatistics {
                         resultSet.getInt("successful_flight_count"),
                         resultSet.getInt("warning_flight_count"),
                         resultSet.getInt("error_flight_count"));
+            }
+        }
+    }
+
+    /**
+     * Counts successfully persisted flights by the date of their parent upload. This keeps filtered dashboard
+     * outcomes aligned with getUploadOutcomeCountsDated, while using flight rows for aircraft metadata.
+     */
+    public static int getSuccessfulFlightCountDated(
+            Connection connection,
+            Integer fleetId,
+            LocalDate startDate,
+            LocalDate endDate,
+            AircraftCategory category,
+            int airframeId)
+            throws SQLException {
+        StringBuilder query = new StringBuilder("""
+                SELECT COUNT(*) AS successful_flight_count
+                FROM flights f
+                INNER JOIN uploads u ON u.id = f.upload_id
+                WHERE u.status <> 'DERIVED'
+                    AND f.status IN ('SUCCESS', 'WARNING')
+                """);
+
+        boolean filterStart = !LocalDate.MIN.equals(startDate);
+        boolean filterEnd = !LocalDate.MAX.equals(endDate);
+        if (fleetId != null) query.append(" AND u.fleet_id = ?");
+        if (filterStart) query.append(" AND u.start_time >= ?");
+        if (filterEnd) query.append(" AND u.start_time < ?");
+        if (category != AircraftCategory.ALL) query.append(" AND ").append(category.sqlCondition("f.airframe_id"));
+        if (airframeId >= 0) query.append(" AND f.airframe_id = ?");
+
+        try (PreparedStatement statement = connection.prepareStatement(query.toString())) {
+            int parameter = 1;
+            if (fleetId != null) statement.setInt(parameter++, fleetId);
+            if (filterStart) statement.setTimestamp(parameter++, Timestamp.valueOf(startDate.atStartOfDay()));
+            if (filterEnd)
+                statement.setTimestamp(parameter++, Timestamp.valueOf(endDate.plusDays(1).atStartOfDay()));
+            if (airframeId >= 0) statement.setInt(parameter, airframeId);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getInt("successful_flight_count");
             }
         }
     }

--- a/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/EventRoutes.kt
+++ b/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/EventRoutes.kt
@@ -100,6 +100,8 @@ object EventRoutes : RouteProvider() {
         val eventNames = ctx.queryParam("eventNames")!!
         val tagName = ctx.queryParam("tagName")!!
         val fleetId = user.fleetId
+        val aircraftCategory = Airframes.AircraftCategory.fromQueryValue(ctx.queryParam("aircraftType"))
+        val aircraftTypeCondition = aircraftCategory.sqlCondition("flights.airframe_id")
 
         Database.getConnection().use { connection ->
             val eventNamesArray = eventNames.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
@@ -132,18 +134,25 @@ object EventRoutes : RouteProvider() {
                 var totalCount = 0
                 for (defId in definitionIds) {
                     val countQuery = if (tagName == "All Tags") {
-                        "SELECT COUNT(*) FROM events WHERE event_definition_id = ? AND fleet_id = ? AND end_time >= ? AND end_time <= ?"
+                        "SELECT COUNT(*) FROM events " +
+                        "JOIN flights ON events.flight_id = flights.id " +
+                        "WHERE events.event_definition_id = ? " +
+                        "AND events.fleet_id = ? " +
+                        "AND events.end_time >= ? " +
+                        "AND events.end_time <= ? " +
+                        "AND $aircraftTypeCondition"
                     } else {
-                        "SELECT COUNT(*) FROM events, flights, flight_tag_map, flight_tags " +
-                        "WHERE events.flight_id = flights.id " +
-                        "AND flights.id = flight_tag_map.flight_id " +
-                        "AND flight_tag_map.tag_id = flight_tags.id " +
-                        "AND events.fleet_id = flight_tags.fleet_id " +
+                        "SELECT COUNT(*) FROM events " +
+                        "JOIN flights ON events.flight_id = flights.id " +
+                        "JOIN flight_tag_map ON flights.id = flight_tag_map.flight_id " +
+                        "JOIN flight_tags ON flight_tag_map.tag_id = flight_tags.id " +
+                        "WHERE events.fleet_id = flight_tags.fleet_id " +
                         "AND events.event_definition_id = ? " +
                         "AND events.fleet_id = ? " +
                         "AND events.end_time >= ? " +
                         "AND events.end_time <= ? " +
-                        "AND flight_tags.name = ?"
+                        "AND flight_tags.name = ? " +
+                        "AND $aircraftTypeCondition"
                     }
 
                     val countStmt = connection.prepareStatement(countQuery)
@@ -177,6 +186,7 @@ object EventRoutes : RouteProvider() {
         val eventNames = ctx.queryParam("eventNames")!!
         val tagName = ctx.queryParam("tagName")!!
         val fleetId = user.fleetId
+        val aircraftCategory = Airframes.AircraftCategory.fromQueryValue(ctx.queryParam("aircraftType"))
 
         Database.getConnection().use { connection ->
             val eventNamesArray = eventNames.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
@@ -198,7 +208,8 @@ object EventRoutes : RouteProvider() {
                     eventName,
                     LocalDate.parse(startDate),
                     LocalDate.parse(endDate),
-                    tagName
+                    tagName,
+                    aircraftCategory
                 )
 
                 eventMap[eventName] = events
@@ -217,6 +228,7 @@ object EventRoutes : RouteProvider() {
 
         val user = SessionUtility.getUser(ctx)
         val fleetId = user.fleetId
+        val aircraftCategory = Airframes.AircraftCategory.fromQueryValue(ctx.queryParam("aircraftType"))
 
         Database.getConnection().use { connection ->
             ctx.json(
@@ -226,7 +238,8 @@ object EventRoutes : RouteProvider() {
                     eventName,
                     LocalDate.parse(startDate),
                     LocalDate.parse(endDate),
-                    tagName
+                    tagName,
+                    aircraftCategory
                 )
             )
         }

--- a/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/FlightRoutes.kt
+++ b/ngafid-www/src/main/kotlin/org/ngafid/www/routes/api/FlightRoutes.kt
@@ -9,6 +9,7 @@ import org.ngafid.core.Database
 import org.ngafid.core.event.Event
 import org.ngafid.core.event.EventDefinition
 import org.ngafid.core.flights.Flight
+import org.ngafid.core.flights.Airframes
 import org.ngafid.core.labels.FlightLabelSection
 import org.ngafid.core.util.FlightTag
 import org.ngafid.www.ErrorResponse
@@ -529,6 +530,8 @@ object FlightRoutes : RouteProvider() {
             val results = mutableListOf<Map<String, Any>>()
 
             val dateClause = StatisticsJavalinRoutes.buildDateClause(startDate, endDate)
+            val aircraftCategory = Airframes.AircraftCategory.fromQueryValue(ctx.queryParam("aircraftType"))
+            val aircraftTypeClause = aircraftCategory.sqlCondition("v.airframe_id")
             val sql = """
                 SELECT
                     a.airframe,
@@ -543,6 +546,8 @@ object FlightRoutes : RouteProvider() {
                     ((? = -1 OR v.airframe_id = ?) AND v.fleet_id = ?)
                 AND
                     $dateClause
+                AND
+                    $aircraftTypeClause
                 GROUP
                     BY a.airframe, v.airframe_id
                 ORDER
@@ -594,6 +599,8 @@ object FlightRoutes : RouteProvider() {
             val results = mutableListOf<Map<String, Any>>()
 
             val dateClause = StatisticsJavalinRoutes.buildDateClause(startDate, endDate)
+            val aircraftCategory = Airframes.AircraftCategory.fromQueryValue(ctx.queryParam("aircraftType"))
+            val aircraftTypeClause = aircraftCategory.sqlCondition("v.airframe_id")
             val sql = """
                 SELECT
                     a.airframe,
@@ -608,6 +615,8 @@ object FlightRoutes : RouteProvider() {
                     (? = -1 OR v.airframe_id = ?)
                 AND
                     $dateClause
+                AND
+                    $aircraftTypeClause
                 GROUP
                     BY a.airframe, v.airframe_id
                 ORDER


### PR DESCRIPTION
Given that we have many different aircraft types now (Fixed Wing, Rotorcraft, UAS) there are many pages on which you may want to only see the information for one of those specific types. This pull request adds a filter in on every page I've deemed relevant (please let me know if there are any I should add/remove)

Pages updated:
- Main/home dashboard
- Aggregate dashboard
- Fleet trends
- Aggregate trends
- Event severities
- Event Heatmap
- Flights Page


Adds a shared aircraft-category model in the backend where data is now sent with aircraft type allowing for filtering. 