### PR TITLE
Fix event count scope on fleet homepage

### DIFF
--- a/ngafid-frontend/src/summary_page.tsx
+++ b/ngafid-frontend/src/summary_page.tsx
@@ -496,7 +496,9 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
             if (airframes.some(airframe => airframe.name === value.airframeName))
                 countData.push(value);
 
-            value.x = value.aggregateTotalEventsCounts;
+            value.x = this.props.aggregate
+                ? value.aggregateTotalEventsCounts
+                : value.totalEventsCounts;
 
             //  let percents = (this.props.aggregate ? fleetPercents : ngafidPercents);
 


### PR DESCRIPTION
Fixes the Event Counts chart on the fleet homepage so it displays data for the user’s current fleet instead of aggregate data from all fleets. Previously, the chart always assigned aggregateTotalEventsCounts to the x-axis, regardless of whether SummaryPage was rendered in fleet or aggregate mode.
