### PR TITLE
fix home page event chart labels and make alphabetical

### DIFF
--- a/ngafid-frontend/src/summary_page.tsx
+++ b/ngafid-frontend/src/summary_page.tsx
@@ -56,6 +56,10 @@ type UploadOutcomeCounts = {
 
 const LOADING_STRING = "...";
 
+const MIN_EVENT_PLOT_HEIGHT = 750;
+const EVENT_PLOT_VERTICAL_PADDING = 100;
+const EVENT_PLOT_HEIGHT_PER_TYPE = 32;
+
 const floatOptions = {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
@@ -452,6 +456,7 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
 
         const countData = [];
         const percentData = [];
+        const displayedEventNames = new Set<string>();
 
         const fleetPercents = {
             name: this.props.aggregate ? "All Fleets" : "Your Fleet",
@@ -491,6 +496,7 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
             value.y = value.names;
             value.type = "bar";
             value.orientation = "h";
+            value.names.forEach((eventName: string) => displayedEventNames.add(eventName));
 
             //Don't add airframes to the count plot that the fleet doesn't have
             if (airframes.some(airframe => airframe.name === value.airframeName))
@@ -546,6 +552,13 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
         //Push ngafidPercents data ('All Other Fleets')
         percentData.push(ngafidPercents);
 
+        const sortedEventNames = Array.from(displayedEventNames)
+            .sort((left, right) => left.localeCompare(right));
+        const eventPlotHeight = Math.max(
+            MIN_EVENT_PLOT_HEIGHT,
+            sortedEventNames.length * EVENT_PLOT_HEIGHT_PER_TYPE + EVENT_PLOT_VERTICAL_PADDING
+        );
+
 
         //for (let j = 0; j < percentData.length; j++) {
         for (let j = percentData.length - 1; j >= 0; j--) {
@@ -579,7 +592,7 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
             barmode: "stack" as const,
             //autosize: false,
             //width: 500,
-            height: 750,
+            height: eventPlotHeight,
             margin: {
                 l: 250,
                 r: 50,
@@ -599,7 +612,14 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
                 gridcolor: plotGridColor
             },
             yaxis: {
-                gridcolor: plotGridColor
+                gridcolor: plotGridColor,
+                autorange: "reversed" as const,
+                categoryorder: "array" as const,
+                categoryarray: sortedEventNames,
+                tickmode: "array" as const,
+                tickvals: sortedEventNames,
+                ticktext: sortedEventNames,
+                automargin: true
             }
         };
 
@@ -607,7 +627,7 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
             title: { text: "Percentage of Flights With Event" },
             //autosize: false,
             //width: 500,
-            height: 750,
+            height: eventPlotHeight,
             margin: {
                 l: 250,
                 r: 50,
@@ -628,7 +648,13 @@ export default class SummaryPage extends React.Component<SummaryPageProps, Summa
             },
             yaxis: {
                 gridcolor: plotGridColor,
-                autorange: "reversed" as const
+                autorange: "reversed" as const,
+                categoryorder: "array" as const,
+                categoryarray: sortedEventNames,
+                tickmode: "array" as const,
+                tickvals: sortedEventNames,
+                ticktext: sortedEventNames,
+                automargin: true
             }
         };
 


### PR DESCRIPTION
previously, if there were too many events, the label would not show for all of them, and the two charts weren't alphabetical and would often not have the same events next to each other. this pull request fixes those issues. 

